### PR TITLE
Feature/435 Expose Vocabulary and Topics through the new REST API

### DIFF
--- a/src/includes/class-wordlift-entity-post-type-service.php
+++ b/src/includes/class-wordlift-entity-post-type-service.php
@@ -146,6 +146,9 @@ class Wordlift_Entity_Post_Type_Service {
 				// 'revisions',
 			),
 			'has_archive'   => true,
+			'show_in_rest'  => true,
+			'rest_base'     => 'vocabulary',
+			'rest_controller_class' => 'Wordlift_REST_Posts_Controller',
 			'menu_icon'     => WP_CONTENT_URL . '/plugins/wordlift/images/svg/wl-vocabulary-icon.svg',
 			// Although we define our slug here, we further manage linking to entities using the Wordlift_Entity_Link_Service.
 			'rewrite'       => array( 'slug' => $this->slug ),

--- a/src/includes/class-wordlift-rest-posts-controller.php
+++ b/src/includes/class-wordlift-rest-posts-controller.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Provides a parent class to expose vocabulary items through the REST api in a custom namespace.
+ *
+ * @since 3.10.0
+ */
+class Wordlift_REST_Posts_Controller extends WP_REST_Posts_Controller {
+	public function __construct( $post_type ) {
+		parent::__construct( $post_type );
+        $this->namespace     = 'wordlift/v1';
+    }
+}

--- a/src/includes/class-wordlift-rest-terms-controller.php
+++ b/src/includes/class-wordlift-rest-terms-controller.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Provides a parent class to expose taxonomy terms through the REST api in a custom namespace.
+ *
+ * @since 3.10.0
+ */
+class Wordlift_REST_Terms_Controller extends WP_REST_Terms_Controller {
+	public function __construct( $taxonomy ) {
+		parent::__construct( $taxonomy );
+        $this->namespace     = 'wordlift/v1';
+    }
+}

--- a/src/includes/class-wordlift-topic-taxonomy-service.php
+++ b/src/includes/class-wordlift-topic-taxonomy-service.php
@@ -108,6 +108,9 @@ class Wordlift_Topic_Taxonomy_Service {
 			'hierarchical'      => true,
 			'show_admin_column' => false,
 			'show_ui'			=> false,
+			'show_in_rest'  	=> true,
+			'rest_base'     	=> 'topics',
+			'rest_controller_class' => 'Wordlift_REST_Terms_Controller',
 			'rewrite'			=> array(
 				'slug'	=> self::TAXONOMY_SLUG
 				)

--- a/src/wordlift.php
+++ b/src/wordlift.php
@@ -244,6 +244,10 @@ function wl_enqueue_scripts() {
 
 add_action( 'wp_enqueue_scripts', 'wl_enqueue_scripts' );
 
+add_action( 'rest_api_init', function () {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-wordlift-rest-posts-controller.php';
+});
+
 /**
  * Hooked to *wp_kses_allowed_html* filter, adds microdata attributes.
  *

--- a/src/wordlift.php
+++ b/src/wordlift.php
@@ -246,6 +246,7 @@ add_action( 'wp_enqueue_scripts', 'wl_enqueue_scripts' );
 
 add_action( 'rest_api_init', function () {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-wordlift-rest-posts-controller.php';
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-wordlift-rest-terms-controller.php';
 });
 
 /**


### PR DESCRIPTION
As discussed in #435 I provided the most abstracted way of exposing both vocabulary and topics through the new WP admin, according to best practices under namespace `wordlift/v1`.