### PR TITLE
Feature/468 add schema.org website markup

### DIFF
--- a/src/includes/class-wordlift-entity-type-service.php
+++ b/src/includes/class-wordlift-entity-type-service.php
@@ -103,6 +103,28 @@ class Wordlift_Entity_Type_Service {
 
 			case 'post':
 			case 'page':
+				/**
+				 * Filter: 'wordlift_disable_website_json_ld' - Allow disabling of the json+ld output
+				 *
+				 * @api bool $display_search Whether or not to display json+ld search on the frontend
+				 */
+				if ( ! apply_filters( 'wordlift_disable_website_json_ld', false ) ) {
+
+					// Get home and blog page ids
+					$ids = array(
+						get_option( 'page_on_front' ),
+						get_option( 'page_for_posts' ),
+					);
+
+					// Determinate if this is home or blog page.
+					if ( in_array( $post_id, $ids ) ) {
+						// Home and Blog pages are considered WebSite.
+						return array(
+							'uri'       => 'http://schema.org/WebSite',
+							'css_class' => 'wl-website',
+						);
+					}
+				}
 				// Posts and pages are considered Articles.
 				return array(
 					'uri'       => 'http://schema.org/Article',

--- a/src/includes/class-wordlift-entity-type-service.php
+++ b/src/includes/class-wordlift-entity-type-service.php
@@ -103,28 +103,6 @@ class Wordlift_Entity_Type_Service {
 
 			case 'post':
 			case 'page':
-				/**
-				 * Filter: 'wordlift_disable_website_json_ld' - Allow disabling of the json+ld output
-				 *
-				 * @api bool $display_search Whether or not to display json+ld search on the frontend
-				 */
-				if ( ! apply_filters( 'wordlift_disable_website_json_ld', false ) ) {
-
-					// Get home and blog page ids
-					$ids = array(
-						get_option( 'page_on_front' ),
-						get_option( 'page_for_posts' ),
-					);
-
-					// Determinate if this is home or blog page.
-					if ( in_array( $post_id, $ids ) ) {
-						// Home and Blog pages are considered WebSite.
-						return array(
-							'uri'       => 'http://schema.org/WebSite',
-							'css_class' => 'wl-website',
-						);
-					}
-				}
 				// Posts and pages are considered Articles.
 				return array(
 					'uri'       => 'http://schema.org/Article',

--- a/src/includes/class-wordlift-jsonld-service.php
+++ b/src/includes/class-wordlift-jsonld-service.php
@@ -31,18 +31,30 @@ class Wordlift_Jsonld_Service {
 	 */
 	private $converter;
 
+
+	/**
+	 * A {@link Wordlift_Website_Jsonld_Converter} instance.
+	 *
+	 * @since  3.14.0
+	 * @access private
+	 * @var \Wordlift_Website_Jsonld_Converter A {@link Wordlift_Website_Jsonld_Converter} instance.
+	 */
+	private $website_converter;
+
 	/**
 	 * Create a JSON-LD service.
 	 *
 	 * @since 3.8.0
 	 *
-	 * @param \Wordlift_Entity_Service $entity_service A {@link Wordlift_Entity_Service} instance.
-	 * @param \Wordlift_Post_Converter $converter      A {@link Wordlift_Uri_To_Jsonld_Converter} instance.
+	 * @param \Wordlift_Entity_Service           $entity_service    A {@link Wordlift_Entity_Service} instance.
+	 * @param \Wordlift_Post_Converter           $converter         A {@link Wordlift_Uri_To_Jsonld_Converter} instance.
+	 * @param \Wordlift_Website_Jsonld_Converter $website_converter A {@link Wordlift_Website_Jsonld_Converter} instance.
 	 */
-	public function __construct( $entity_service, $converter ) {
+	public function __construct( $entity_service, $converter, $website_converter ) {
 
-		$this->entity_service = $entity_service;
-		$this->converter      = $converter;
+		$this->entity_service    = $entity_service;
+		$this->converter         = $converter;
+		$this->website_converter = $website_converter;
 
 	}
 
@@ -64,6 +76,25 @@ class Wordlift_Jsonld_Service {
 		// See https://github.com/insideout10/wordlift-plugin/issues/406.
 		// See https://codex.wordpress.org/AJAX_in_Plugins.
 		ob_clean();
+
+		// Switch to Website converter if is home page.
+		if ( isset( $_REQUEST['homepage'] ) ) {
+			/**
+			 * Filter: 'wordlift_disable_website_json_ld' - Allow disabling of the json+ld output.
+			 *
+			 * @since  3.14.0
+			 * @api bool $display_search Whether or not to display json+ld search on the frontend.
+			 */
+			if ( ! apply_filters( 'wordlift_disable_website_json_ld', false ) ) {
+				// Set a reference to the website_converter.
+				$website_converter = $this->website_converter;
+
+				$jsonld = array( $website_converter->create_schema( $_REQUEST ) );
+
+				// Send JSON-LD.
+				wp_send_json( $jsonld );
+			}
+		}
 
 		// If no id has been provided return an empty array.
 		if ( ! isset( $_REQUEST['id'] ) ) {

--- a/src/includes/class-wordlift-jsonld-service.php
+++ b/src/includes/class-wordlift-jsonld-service.php
@@ -89,10 +89,8 @@ class Wordlift_Jsonld_Service {
 				// Set a reference to the website_converter.
 				$website_converter = $this->website_converter;
 
-				$jsonld = array( $website_converter->create_schema( $_REQUEST ) );
-
 				// Send JSON-LD.
-				wp_send_json( $jsonld );
+				wp_send_json( $website_converter->create_schema() );
 			}
 		}
 

--- a/src/includes/class-wordlift-jsonld-website-converter.php
+++ b/src/includes/class-wordlift-jsonld-website-converter.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Converters: JSON-LD Website Converter.
+ *
+ * This file defines a converter for home and blog pages to JSON-LD array.
+ *
+ * @since   3.14.0
+ * @package Wordlift
+ */
+
+/**
+ * Define the {@link Wordlift_Website_Jsonld_Converter} class.
+ *
+ * @since 3.14.0
+ */
+class Wordlift_Website_Jsonld_Converter extends Wordlift_Post_To_Jsonld_Converter {
+
+	/**
+	 * Convert the home/blog page to a JSON-LD array.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @param array $request An array of homepage info.
+	 *
+	 * @return array A JSON-LD array.
+	 */
+	public function create_schema( $request ) {
+
+		// Check if we have home/blog page id.
+		if ( isset( $request['id'] ) ) {
+			$post_id = $request['id'];
+
+			// Get the base JSON-LD and the list of entities referenced by this entity.
+			$jsonld = parent::convert( $post_id, $references );
+		} else {
+			// Create new jsonld, because we don't have id.
+			$jsonld = array(
+				'@context' => 'http://schema.org',
+			);
+		}
+
+		// Change the jsonld to include site info, rather page info.
+		$this->apply_website_info_to_json_ld( $jsonld );
+
+		// Add seach action to jsonld
+		$this->set_search_action( $jsonld );
+
+		return $jsonld;
+	}
+
+	/**
+	 * Update the JSON-LD structure to match the `WebSite` schema.org class.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @param array $params  The JSON-LD structure.
+	*/
+	public function apply_website_info_to_json_ld( &$params ) {
+		// Change values so they will be accurate for homepage
+
+		// Change schema properties.
+		$params['@type']       = 'WebSite';
+		$params['headline']    = get_bloginfo( 'name' );
+		$params['description'] = get_bloginfo( 'description' );
+		$params['url']         = home_url( '/' );
+	}
+
+	/**
+	 * Add SearchAction part to the schema
+	 *
+	 * @since 3.14.0
+	 *
+	 * @param array $params The parameters array.
+	 */
+	private function set_search_action( &$params ) {
+		/**
+		 * Filter: 'wordlift_json_ld_search_url' - Allows filtering of the search URL.
+		 *
+		 * @since  3.14.0
+		 * @api string $search_url The search URL for this site with a `{search_term_string}` variable.
+		 */
+		$search_url = apply_filters( 'wordlift_json_ld_search_url', home_url( '/' ) . '?s={search_term_string}' );
+
+		// Add search action
+		$params['potentialAction'] = array(
+			'@type'       => 'SearchAction',
+			'target'      => $search_url,
+			'query-input' => 'required name=search_term_string',
+		);
+	}
+}

--- a/src/includes/class-wordlift-jsonld-website-converter.php
+++ b/src/includes/class-wordlift-jsonld-website-converter.php
@@ -24,45 +24,25 @@ class Wordlift_Website_Jsonld_Converter extends Wordlift_Post_To_Jsonld_Converte
 	 *
 	 * @return array A JSON-LD array.
 	 */
-	public function create_schema( $request ) {
+	public function create_schema() {
 
-		// Check if we have home/blog page id.
-		if ( isset( $request['id'] ) ) {
-			$post_id = $request['id'];
+		// Create new jsonld.
+		$jsonld = array(
+			'@context'      => 'http://schema.org',
+			'@type'         => 'WebSite',
+			'name'          => get_bloginfo( 'name' ),
+			'alternateName' => get_bloginfo( 'description' ),
+			'url'           => home_url( '/' ),
+		);
 
-			// Get the base JSON-LD and the list of entities referenced by this entity.
-			$jsonld = parent::convert( $post_id, $references );
-		} else {
-			// Create new jsonld, because we don't have id.
-			$jsonld = array(
-				'@context' => 'http://schema.org',
-			);
-		}
+		// Add publisher information.
+		$this->set_publisher( $jsonld );
 
-		// Change the jsonld to include site info, rather page info.
-		$this->apply_website_info_to_json_ld( $jsonld );
-
-		// Add seach action to jsonld
+		// Add search action.
 		$this->set_search_action( $jsonld );
 
+		// Return the jsonld schema.
 		return $jsonld;
-	}
-
-	/**
-	 * Update the JSON-LD structure to match the `WebSite` schema.org class.
-	 *
-	 * @since 3.14.0
-	 *
-	 * @param array $params  The JSON-LD structure.
-	*/
-	public function apply_website_info_to_json_ld( &$params ) {
-		// Change values so they will be accurate for homepage
-
-		// Change schema properties.
-		$params['@type']       = 'WebSite';
-		$params['headline']    = get_bloginfo( 'name' );
-		$params['description'] = get_bloginfo( 'description' );
-		$params['url']         = home_url( '/' );
 	}
 
 	/**

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -134,16 +134,6 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 
 		}
 
-		/**
-		 * Filter: 'wordlift_disable_website_json_ld' - Allow disabling of the json+ld output
-		 *
-		 * @api bool $display_search Whether or not to display json+ld search on the frontend
-		 */
-		if ( ! apply_filters( 'wordlift_disable_website_json_ld', false ) ) {
-			// Change jsonld if is home or blog page
-			$this->change_jsonld_if_homepage( $jsonld, $post_id );
-		}
-
 		return $jsonld;
 	}
 
@@ -213,47 +203,5 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 		$params['publisher']['logo']['width']  = $attachment[1];
 		$params['publisher']['logo']['height'] = $attachment[2];
 
-	}
-
-	function change_jsonld_if_homepage( &$params, $post_id ) {
-		// Get home & blog page ids
-		$ids = array(
-			get_option( 'page_on_front' ),
-			get_option( 'page_for_posts' ),
-		);
-
-		// Determinate if this is home or blog page.
-		if ( in_array( $post_id, $ids ) ) {
-			// Change values so they will be accurate on homepage
-			$params['headline']    = get_bloginfo( 'name' );
-			$params['description'] = get_bloginfo( 'description' );
-			$params['url']         = home_url('/');
-
-			// Set the search action.
-			$this->set_search_action( $params );
-		}
-	}
-
-	/**
-	 * Enrich the provided params array with publisher data, if available.
-	 *
-	 * @since 3.10.0
-	 *
-	 * @param array $params The parameters array.
-	 */
-	private function set_search_action( &$params ) {
-		/**
-		 * Filter: 'wordlift_json_ld_search_url' - Allows filtering of the search URL.
-		 *
-		 * @api string $search_url The search URL for this site with a `{search_term_string}` variable.
-		 */
-		$search_url = apply_filters( 'wordlift_json_ld_search_url', home_url( '/' ) . '?s={search_term_string}' );
-
-		// Add search action
-		$params['potentialAction'] = array(
-			'@type'       => 'SearchAction',
-			'target'      => $search_url,
-			'query-input' => 'required name=search_term_string',
-		);
 	}
 }

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -134,6 +134,16 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 
 		}
 
+		/**
+		 * Filter: 'wordlift_disable_website_json_ld' - Allow disabling of the json+ld output
+		 *
+		 * @api bool $display_search Whether or not to display json+ld search on the frontend
+		 */
+		if ( ! apply_filters( 'wordlift_disable_website_json_ld', false ) ) {
+			// Change jsonld if is home or blog page
+			$this->change_jsonld_if_homepage( $jsonld, $post_id );
+		}
+
 		return $jsonld;
 	}
 
@@ -205,4 +215,45 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 
 	}
 
+	function change_jsonld_if_homepage( &$params, $post_id ) {
+		// Get home & blog page ids
+		$ids = array(
+			get_option( 'page_on_front' ),
+			get_option( 'page_for_posts' ),
+		);
+
+		// Determinate if this is home or blog page.
+		if ( in_array( $post_id, $ids ) ) {
+			// Change values so they will be accurate on homepage
+			$params['headline']    = get_bloginfo( 'name' );
+			$params['description'] = get_bloginfo( 'description' );
+			$params['url']         = home_url('/');
+
+			// Set the search action.
+			$this->set_search_action( $params );
+		}
+	}
+
+	/**
+	 * Enrich the provided params array with publisher data, if available.
+	 *
+	 * @since 3.10.0
+	 *
+	 * @param array $params The parameters array.
+	 */
+	private function set_search_action( &$params ) {
+		/**
+		 * Filter: 'wordlift_json_ld_search_url' - Allows filtering of the search URL.
+		 *
+		 * @api string $search_url The search URL for this site with a `{search_term_string}` variable.
+		 */
+		$search_url = apply_filters( 'wordlift_json_ld_search_url', home_url( '/' ) . '?s={search_term_string}' );
+
+		// Add search action
+		$params['potentialAction'] = array(
+			'@type'       => 'SearchAction',
+			'target'      => $search_url,
+			'query-input' => 'required name=search_term_string',
+		);
+	}
 }

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -144,7 +144,7 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 	 *
 	 * @param array $params The parameters array.
 	 */
-	private function set_publisher( &$params ) {
+	protected function set_publisher( &$params ) {
 
 		// If the publisher id isn't set don't do anything.
 		if ( null === $publisher_id = $this->configuration_service->get_publisher_id() ) {

--- a/src/includes/class-wordlift.php
+++ b/src/includes/class-wordlift.php
@@ -247,6 +247,15 @@ class Wordlift {
 	protected $jsonld_service;
 
 	/**
+	 * A {@link Wordlift_Website_Jsonld_Converter} instance.
+	 *
+	 * @since  3.14.0
+	 * @access protected
+	 * @var \Wordlift_Website_Jsonld_Converter $jsonld_website_converter A {@link Wordlift_Website_Jsonld_Converter} instance.
+	 */
+	protected $jsonld_website_converter;
+
+	/**
 	 *
 	 * @since  3.7.0
 	 * @access private
@@ -676,6 +685,7 @@ class Wordlift {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wordlift-postid-to-jsonld-converter.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wordlift-entity-post-to-jsonld-converter.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wordlift-post-to-jsonld-converter.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wordlift-jsonld-website-converter.php';
 
 		/**
 		 * Load the content filter.
@@ -935,7 +945,8 @@ class Wordlift {
 		$this->entity_post_to_jsonld_converter = new Wordlift_Entity_Post_To_Jsonld_Converter( $this->entity_type_service, $this->entity_service, $this->user_service, $attachment_service, $property_getter );
 		$this->post_to_jsonld_converter        = new Wordlift_Post_To_Jsonld_Converter( $this->entity_type_service, $this->entity_service, $this->user_service, $attachment_service, $this->configuration_service );
 		$this->postid_to_jsonld_converter      = new Wordlift_Postid_To_Jsonld_Converter( $this->entity_service, $this->entity_post_to_jsonld_converter, $this->post_to_jsonld_converter );
-		$this->jsonld_service                  = new Wordlift_Jsonld_Service( $this->entity_service, $this->postid_to_jsonld_converter );
+		$this->jsonld_website_converter        = new Wordlift_Website_Jsonld_Converter( $this->entity_type_service, $this->entity_service, $this->user_service, $attachment_service, $this->configuration_service );
+		$this->jsonld_service                  = new Wordlift_Jsonld_Service( $this->entity_service, $this->postid_to_jsonld_converter, $this->jsonld_website_converter );
 
 		// Create an instance of the Key Validation service. This service is later hooked to provide an AJAX call (only for admins).
 		$this->key_validation_service = new Wordlift_Key_Validation_Service();

--- a/src/public/class-wordlift-public.php
+++ b/src/public/class-wordlift-public.php
@@ -110,17 +110,6 @@ class Wordlift_Public {
 		// Add flag that we are on home/blog page.
 		if ( is_home() || is_front_page()  ) {
 			$settings['isHome'] = true;
-
-			// Check if we are on blog page and change the id.
-			if ( is_home() ) {
-				// Get blogpage id.
-				$maybe_blogpage_id = get_option( 'page_for_posts' );
-
-				// Check if we have blog page set and use it's id.
-				if ( ! empty( $maybe_blogpage_id ) ) {
-					$settings['postId'] = $maybe_blogpage_id;
-				}
-			}
 		}
 
 		// Note that we switched the js to be loaded in footer, since it is loading

--- a/src/public/class-wordlift-public.php
+++ b/src/public/class-wordlift-public.php
@@ -105,8 +105,22 @@ class Wordlift_Public {
 		// If we're in a single page, then print out the post id.
 		if ( is_singular() ) {
 			$settings['postId'] = get_the_ID();
-		} elseif ( is_home() ) {
-			$settings['postId'] = get_option( 'page_for_posts' );
+		}
+
+		// Add flag that we are on home/blog page.
+		if ( is_home() || is_front_page()  ) {
+			$settings['isHome'] = true;
+
+			// Check if we are on blog page and change the id.
+			if ( is_home() ) {
+				// Get blogpage id.
+				$maybe_blogpage_id = get_option( 'page_for_posts' );
+
+				// Check if we have blog page set and use it's id.
+				if ( ! empty( $maybe_blogpage_id ) ) {
+					$settings['postId'] = $maybe_blogpage_id;
+				}
+			}
 		}
 
 		// Note that we switched the js to be loaded in footer, since it is loading

--- a/src/public/class-wordlift-public.php
+++ b/src/public/class-wordlift-public.php
@@ -105,6 +105,8 @@ class Wordlift_Public {
 		// If we're in a single page, then print out the post id.
 		if ( is_singular() ) {
 			$settings['postId'] = get_the_ID();
+		} elseif ( is_home() ) {
+			$settings['postId'] = get_option( 'page_for_posts' );
 		}
 
 		// Note that we switched the js to be loaded in footer, since it is loading

--- a/src/public/js/wordlift-public.js
+++ b/src/public/js/wordlift-public.js
@@ -22,7 +22,7 @@
 
 			// Check that we have param that indicates we are on homepage, and add it to the requestData.
 			if ( typeof( settings.isHome ) !== 'undefined' ) {
-				requestData.homepage = 'true';
+				requestData.homepage = true;
 			}
 
 			// Request the JSON-LD data.

--- a/src/public/js/wordlift-public.js
+++ b/src/public/js/wordlift-public.js
@@ -3,18 +3,30 @@
 		'use strict';
 
 		$( function() {
-
-			// Check that we have a post id, otherwise exit.
-			if ( typeof settings.postId === 'undefined' ) {
+			// Check that we have a post id or it's homepage, otherwise exit.
+			if (
+			    typeof( settings.postId ) === 'undefined' &&
+			    typeof( settings.isHome ) === 'undefined'
+			) {
 				return;
 			}
 
-			// Request the JSON-LD data.
-			$.post( settings.ajaxUrl, {
+			var requestData = {
 				action: 'wl_jsonld',
-				id: settings.postId
-			}, function( data ) {
+			};
 
+			// Check that we have a post id, and add it to the requestData.
+			if ( typeof( settings.postId ) !== 'undefined' ) {
+				requestData.id = settings.postId;
+			}
+
+			// Check that we have param that indicates we are on homepage, and add it to the requestData.
+			if ( typeof( settings.isHome ) !== 'undefined' ) {
+				requestData.homepage = 'true';
+			}
+
+			// Request the JSON-LD data.
+			$.post( settings.ajaxUrl, requestData, function( data ) {
 				// Append the data in the page head.
 				$('head').append( '<script type="application/ld+json">'+JSON.stringify(data)+'</s' + 'cript>' );
 

--- a/tests/class-wordlift-ajax-unit-test-case.php
+++ b/tests/class-wordlift-ajax-unit-test-case.php
@@ -15,12 +15,22 @@ require_once( 'functions.php' );
  * @since 3.8.0
  */
 abstract class Wordlift_Ajax_Unit_Test_Case extends WP_Ajax_UnitTestCase {
+	/**
+	 * The {@link Wordlift_UnitTest_Factory_For_Entity} instance.
+	 *
+	 * @since  3.14.0
+	 * @access protected
+	 * @var \Wordlift_UnitTest_Factory_For_Entity $entity_factory The {@link Wordlift_UnitTest_Factory_For_Entity} instance.
+	 */
+	protected $entity_factory;
 
 	function setUp() {
 		parent::setUp();
 
 		// Default behaviour: push entities to the remote Linked Data store.
 		Wordlift_Unit_Test_Case::turn_off_entity_push();
+
+		$this->entity_factory = new Wordlift_UnitTest_Factory_For_Entity( $this->factory );
 
 		// Configure WordPress with the test settings.
 		wl_configure_wordpress_test();

--- a/tests/test-jsonld-service.php
+++ b/tests/test-jsonld-service.php
@@ -244,12 +244,13 @@ class Wordlift_Jsonld_Service_Test extends Wordlift_Ajax_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the JSON-LD WebSite
+	 * Test JSON-LD WebSite.
 	 *
+	 * @since 3.14.0
 	 */
 	public function test_jsonld_website() {
-		$name              = rand_str();
-		$description       = rand_str();
+		$name        = rand_str();
+		$description = rand_str();
 
 		// Create homepage
 		$homepage_id = $this->factory->post->create( array(
@@ -268,12 +269,13 @@ class Wordlift_Jsonld_Service_Test extends Wordlift_Ajax_Unit_Test_Case {
 		// Get site info
 		$headline    = get_bloginfo( 'name' );
 		$description = get_bloginfo( 'description' );
-		$url         = home_url('/');
+		$url         = home_url( '/' );
 		$target      = $url . '?s={search_term_string}';
 
 		// Set up a default request
-		$_GET['action'] = 'wl_jsonld';
-		$_GET['id']     = $homepage_id;
+		$_GET['action']   = 'wl_jsonld';
+		$_GET['id']       = $homepage_id;
+		$_GET['homepage'] = 'true';
 
 		// Make the request
 		try {
@@ -284,7 +286,6 @@ class Wordlift_Jsonld_Service_Test extends Wordlift_Ajax_Unit_Test_Case {
 
 		// Get response
 		$response = json_decode( $this->_last_response );
-
 		$this->assertTrue( is_array( $response ) );
 
 		$this->assertCount( 1, $response );
@@ -318,17 +319,17 @@ class Wordlift_Jsonld_Service_Test extends Wordlift_Ajax_Unit_Test_Case {
 
 		$this->assertArrayHasKey( 'target', $potential_action );
 		$this->assertEquals( $target, $potential_action['target'] );
+
 	}
 
-
 	/**
-	 * Test that the JSON-LD WebSite is working.
+	 * Test that disable website filter is working.
 	 *
-	 * @since 3.8.0
+	 * @since 3.14.0
 	 */
-	public function test_disavble_jsonld_website() {
-		$name              = rand_str();
-		$description       = rand_str();
+	public function test_disable_jsonld_website() {
+		$name        = rand_str();
+		$description = rand_str();
 
 		// Create homepage
 		$homepage_id = $this->factory->post->create( array(
@@ -347,7 +348,7 @@ class Wordlift_Jsonld_Service_Test extends Wordlift_Ajax_Unit_Test_Case {
 		// Get site info
 		$headline    = get_bloginfo( 'name' );
 		$description = get_bloginfo( 'description' );
-		$url         = home_url('/');
+		$url         = home_url( '/' );
 		$target      = $url . '?s={search_term_string}';
 
 		// Set up a default request
@@ -389,15 +390,77 @@ class Wordlift_Jsonld_Service_Test extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertNotEquals( $headline, $jsonld_1['headline'] );
 	}
 
+	/**
+	 * Test that the JSON-LD WebSite works even without homepage.
+	 *
+	 * @since 3.14.0
+	 */
+	public function test_jsonld_website_without_homepage() {
+		$description = rand_str();
+
+		// Set our page as homepage & update the site description
+		update_option( 'blogdescription', $description );
+
+		// Get site info
+		$headline    = get_bloginfo( 'name' );
+		$description = get_bloginfo( 'description' );
+		$url         = home_url( '/' );
+		$target      = $url . '?s={search_term_string}';
+
+		$_GET['action']   = 'wl_jsonld';
+		$_GET['homepage'] = true;
+
+		// Make the request
+		try {
+			$this->_handleAjax( 'wl_jsonld' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertTrue( is_array( $response ) );
+
+		$this->assertCount( 1, $response );
+
+		$jsonld_1 = get_object_vars( $response[0] );
+
+		$this->assertTrue( is_array( $jsonld_1 ) );
+		$this->assertArrayHasKey( '@context', $jsonld_1 );
+		$this->assertEquals( 'http://schema.org', $jsonld_1['@context'] );
+
+		$this->assertArrayHasKey( '@type', $jsonld_1 );
+		$this->assertEquals( 'WebSite', $jsonld_1['@type'] );
+
+		$this->assertArrayHasKey( 'description', $jsonld_1 );
+		$this->assertEquals( $description, $jsonld_1['description'] );
+
+		$this->assertArrayHasKey( 'headline', $jsonld_1 );
+		$this->assertEquals( $headline, $jsonld_1['headline'] );
+
+		$this->assertArrayHasKey( 'url', $jsonld_1 );
+		$this->assertEquals( $url, $jsonld_1['url'] );
+
+		$potential_action = get_object_vars( $jsonld_1['potentialAction'] );
+
+		$this->assertArrayHasKey( '@type', $potential_action );
+		$this->assertEquals( 'SearchAction', $potential_action['@type'] );
+
+		$this->assertArrayHasKey( 'target', $potential_action );
+		$this->assertEquals( $target, $potential_action['target'] );
+
+		$this->assertArrayHasKey( 'target', $potential_action );
+		$this->assertEquals( $target, $potential_action['target'] );
+	}
 
 	/**
-	 * Test that the JSON-LD WebSite is working.
+	 * Test that the JSON-LD WebSite search_url filter is working.
 	 *
-	 * @since 3.8.0
+	 * @since 3.14.0
 	 */
 	public function test_change_jsonld_website_search_target() {
-		$name              = rand_str();
-		$description       = rand_str();
+		$name        = rand_str();
+		$description = rand_str();
 
 		// Create homepage
 		$homepage_id = $this->factory->post->create( array(
@@ -414,18 +477,22 @@ class Wordlift_Jsonld_Service_Test extends Wordlift_Ajax_Unit_Test_Case {
 		update_option( 'blogdescription', $description );
 
 		// Get site info
-		$headline        = get_bloginfo( 'name' );
-		$description     = get_bloginfo( 'description' );
-		$url             = home_url('/');
-		$target          = $url . '?s={search_term_string}';
+		$headline    = get_bloginfo( 'name' );
+		$description = get_bloginfo( 'description' );
+		$url         = home_url( '/' );
+		$target      = $url . '?s={search_term_string}';
 
 		// Change the search target
-		$modified_target = str_replace('{search_term_string}', '', $target);
+		$modified_target = str_replace( '{search_term_string}', '', $target );
 
-		// Set up a default request
-		$_GET['action'] = 'wl_jsonld';
-		$_GET['id']     = $homepage_id;
-		add_filter( 'wordlift_json_ld_search_url', array( $this, 'change_search_url' ) );
+		$_GET['action']   = 'wl_jsonld';
+		$_GET['id']       = $homepage_id;
+		$_GET['homepage'] = true;
+
+		add_filter( 'wordlift_json_ld_search_url', array(
+			$this,
+			'change_search_url'
+		) );
 
 		// Make the request
 		try {
@@ -473,7 +540,16 @@ class Wordlift_Jsonld_Service_Test extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertEquals( $modified_target, $potential_action['target'] );
 	}
 
+	/**
+	 * Test the filter `wordlift_json_ld_search_url`.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @param string $url The default URL.
+	 *
+	 * @return string A modified URL.
+	 */
 	public function change_search_url( $url ) {
-		return str_replace('{search_term_string}', '', $url);
+		return str_replace( '{search_term_string}', '', $url );
 	}
 }


### PR DESCRIPTION
Fixes #468 

#### Changes proposed in this Pull Request:
 * Change schema.org to [WebSite](http://schema.org/WebSite) for home and blog pages

Currently home page is uses schema.org/Article, while there is a schema.org/WebSite that can be used. In this PR there are two conditions that check if the home or blog page is being displayed and change the schema to WebSIte. It will also add default [Search Action].(https://developers.google.com/search/docs/data-types/sitelinks-searchbox)

There are also two filters (both documented in the code):
* `wordlift_disable_website_json_ld ` that allow you to disable the WebSite markup in case other plugin provides it.
* `wordlift_json_ld_search_url ` that allow you to change the default search url

#### Testing instructions for homepage:

* Activate the plugin and add your API key
* Create sample page
* Go to Settings > Reading and make that page homepage (Front page)
* Open the page and make sure that `application/ld+json` script has been changed to WebSite

#### Testing instructions for blogpage:

* Activate the plugin and add your API key
* Create sample page
* Go to Settings > Reading and make that page blog page (Posts page)
* Open the page and make sure that `application/ld+json` script has been changed to WebSite

Currently there are some errors related to publisher, that will be better to be addressed in another PR, so we can keep this one small.

![website-schema-check](https://cldup.com/mvOCYBEckT-3000x3000.png)

There are also three unit tests added that covered new schema and the two filters.

PS: Feedback welcome 