### PR TITLE
Hotfix/565 allow empty vocabulary path on compatible permalink configuration

### DIFF
--- a/src/admin/js/wordlift-admin-setup.js
+++ b/src/admin/js/wordlift-admin-setup.js
@@ -93,7 +93,8 @@
                     delay($this, function () {
 
                         // An empty value or a value starting/ending with an alphanumeric character.
-                        if (0 === $this.val().length || /^[a-z0-9]+(?:[a-z0-9\-_]*[a-z0-9]+)?$/i.test($this.val()))
+                        // An empty value is avaible only when WP permalink structure is set as '/%postname%/'
+                        if ((0 === $this.val().length && '/%postname%/' === settings.permalink) || /^[a-z0-9]+(?:[a-z0-9\-_]*[a-z0-9]+)?$/i.test($this.val()))
                             $this.addClass('valid');
                         else
                             $this.addClass('invalid');

--- a/src/admin/partials/wordlift-admin-setup.php
+++ b/src/admin/partials/wordlift-admin-setup.php
@@ -27,13 +27,16 @@
 	) );
 	wp_enqueue_script( 'wordlift-admin-setup', plugin_dir_url( dirname( __FILE__ ) ) . 'js/wordlift-admin-setup.js', array( 'jquery' ) );
 
+	//Get wp_permalink structure
+	$permalink_structure = get_option('permalink_structure');
 	// Set configuration settings.
 	wp_localize_script( 'wordlift-admin-setup', '_wlAdminSetup', array(
-		'ajaxUrl' => parse_url( self_admin_url( 'admin-ajax.php' ), PHP_URL_PATH ),
-		'action'  => 'wl_validate_key',
-		'media'   => array(
-			'title' => __( 'WordLift Choose Logo', 'wordlift' ),
-			'button' => array( 'text' => __( 'Choose Logo', 'wordlift' ) ),
+		'ajaxUrl'   => parse_url( self_admin_url( 'admin-ajax.php' ), PHP_URL_PATH ),
+		'action'    => 'wl_validate_key',
+		'permalink' => $permalink_structure,
+		'media'     => array(
+			'title'   => __( 'WordLift Choose Logo', 'wordlift' ),
+			'button'  => array( 'text' => __( 'Choose Logo', 'wordlift' ) ),
 		),
 	) );
 


### PR DESCRIPTION
See [#565](https://github.com/insideout10/wordlift-plugin/issues/565).
Proposed changes enable setting an empty vocabulary path on WL Setup only if permalink configurations is compatible.