### PR TITLE
Feature 607: Add autocomplete API

### DIFF
--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -56,7 +56,7 @@ class Wordlift_Autocomplete_Adapter {
 
 		// Return error if the query param is empty.
 		if ( ! empty( $_REQUEST['query'] ) ) {
-			$query = wp_unslash( $_REQUEST['query'] );
+			$query = sanitize_text_field( wp_unslash( $_REQUEST['query'] ) );
 		} else {
 			wp_send_json_error( array(
 				'message' => 'The query param is empty!',

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -68,8 +68,6 @@ class Wordlift_Autocomplete_Adapter {
 
 		// Make request.
 		$response = $this->autocomplete_service->make_request( $query );
-		// Decode response body.
-		$suggestions = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		// Clear any buffer.
 		ob_clean();
@@ -78,12 +76,20 @@ class Wordlift_Autocomplete_Adapter {
 		if ( ! is_wp_error( $response ) && 200 === (int) $response['response']['code'] ) {
 			// Echo the response.
 			wp_send_json_success( array(
-				'suggestions' => $suggestions,
+				json_decode( wp_remote_retrieve_body( $response ), true )
 			) );
 		} else {
+			// Default error message.
+			$error_message = __( 'Something went wrong.' );
+
+			// Get the real error message if there is WP_Error.
+			if ( is_wp_error( $response ) ) {
+				$error_message = $response->get_error_message();
+			}
+
 			// There is an error, so send error message.
 			wp_send_json_error( array(
-				'message' => __( 'Something went wrong.' ),
+				'message' => $error_message,
 			) );
 		}
 	}

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -49,8 +49,8 @@ class Wordlift_Autocomplete_Adapter {
 	 */
 	public function wl_autocomplete() {
 		if (
-		    ! isset( $_REQUEST['_wpnonce'] ) ||
-		    ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' )
+			! isset( $_REQUEST['_wpnonce'] ) ||
+			! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' )
 		) {
 			wp_send_json_error( array(
 				'message' => 'Nonce field doens\'t match',

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -48,17 +48,26 @@ class Wordlift_Autocomplete_Adapter {
 	 * @since 3.15.0
 	 */
 	public function wl_autocomplete() {
-		if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'wordlift_autocomplete' ) ) {
-			wp_send_json_error( array( 'message' => 'Nonce field doens\'t match' ) );
+		if (
+			! empty( $_REQUEST['_wpnonce'] ) &&
+			! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' )
+		) {
+			wp_send_json_error( array(
+				'message' => 'Nonce field doens\'t match'
+			) );
 		}
 
-		// Return error if the query param si empty.
-		if ( empty( $_REQUEST['query'] ) ) {
-			wp_send_json_error( array( 'message' => 'The query param is empty!' ) );
+		// Return error if the query param is empty.
+		if ( ! empty( $_REQUEST['query'] ) ) {
+			$query = wp_unslash( $_REQUEST['query'] );
+		} else {
+			wp_send_json_error( array(
+				'message' => 'The query param is empty!'
+			) );
 		}
 
 		// Make request.
-		$response = $this->autocomplete_service->make_request( $_REQUEST['query'] );
+		$response = $this->autocomplete_service->make_request( $query );
 		// Decode response body.
 		$suggestions = json_decode( wp_remote_retrieve_body( $response ), true );
 
@@ -68,10 +77,14 @@ class Wordlift_Autocomplete_Adapter {
 		// If the response is valid, then send the suggestions.
 		if ( ! is_wp_error( $response ) && 200 === (int) $response['response']['code'] ) {
 			// Echo the response.
-			wp_send_json_success( array( 'suggestions' => $suggestions ) );
+			wp_send_json_success( array(
+				'suggestions' => $suggestions
+			) );
 		} else {
 			// There is an error, so send error message.
-			wp_send_json_error( array( 'message' => __( 'Something went wrong.' ) ) );
+			wp_send_json_error( array(
+				'message' => __( 'Something went wrong.' )
+			) );
 		}
 	}
 }

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -50,7 +50,7 @@ class Wordlift_Autocomplete_Adapter {
 	public function wl_autocomplete() {
 		if (
 			! isset( $_REQUEST['_wpnonce'] ) || // Input var okay.
-			! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' ) // Input var okay.
+			! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'wordlift_autocomplete' ) // Input var okay.
 		) {
 			wp_send_json_error( array(
 				'message' => 'Nonce field doens\'t match',

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -76,7 +76,7 @@ class Wordlift_Autocomplete_Adapter {
 		if ( ! is_wp_error( $response ) && 200 === (int) $response['response']['code'] ) {
 			// Echo the response.
 			wp_send_json_success( array(
-				json_decode( wp_remote_retrieve_body( $response ), true )
+				json_decode( wp_remote_retrieve_body( $response ), true ),
 			) );
 		} else {
 			// Default error message.

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -49,8 +49,8 @@ class Wordlift_Autocomplete_Adapter {
 	 */
 	public function wl_autocomplete() {
 		if (
-			! isset( $_REQUEST['_wpnonce'] ) ||
-			! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' )
+			! isset( $_REQUEST['_wpnonce'] ) || // Input var okay.
+			! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' ) // Input var okay.
 		) {
 			wp_send_json_error( array(
 				'message' => 'Nonce field doens\'t match',
@@ -58,8 +58,8 @@ class Wordlift_Autocomplete_Adapter {
 		}
 
 		// Return error if the query param is empty.
-		if ( ! empty( $_REQUEST['query'] ) ) {
-			$query = sanitize_text_field( wp_unslash( $_REQUEST['query'] ) );
+		if ( ! empty( $_REQUEST['query'] ) ) { // Input var okay.
+			$query = sanitize_text_field( wp_unslash( $_REQUEST['query'] ) ); // Input var okay.
 		} else {
 			wp_send_json_error( array(
 				'message' => 'The query param is empty!',

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -50,7 +50,7 @@ class Wordlift_Autocomplete_Adapter {
 	public function wl_autocomplete() {
 		if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' ) ) {
 			wp_send_json_error( array(
-				'message' => 'Nonce field doens\'t match'
+				'message' => 'Nonce field doens\'t match',
 			) );
 		}
 
@@ -59,7 +59,7 @@ class Wordlift_Autocomplete_Adapter {
 			$query = wp_unslash( $_REQUEST['query'] );
 		} else {
 			wp_send_json_error( array(
-				'message' => 'The query param is empty!'
+				'message' => 'The query param is empty!',
 			) );
 		}
 
@@ -75,12 +75,12 @@ class Wordlift_Autocomplete_Adapter {
 		if ( ! is_wp_error( $response ) && 200 === (int) $response['response']['code'] ) {
 			// Echo the response.
 			wp_send_json_success( array(
-				'suggestions' => $suggestions
+				'suggestions' => $suggestions,
 			) );
 		} else {
 			// There is an error, so send error message.
 			wp_send_json_error( array(
-				'message' => __( 'Something went wrong.' )
+				'message' => __( 'Something went wrong.' ),
 			) );
 		}
 	}

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -89,6 +89,7 @@ class Wordlift_Autocomplete_Adapter {
 
 			// There is an error, so send error message.
 			wp_send_json_error( array(
+				/* translators: Placeholders: %s - the error message that will be returned. */
 				'message' => sprintf( esc_html__( '%s', 'wordlift' ), $error_message ),
 			) );
 		}

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -53,7 +53,7 @@ class Wordlift_Autocomplete_Adapter {
 			! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'wordlift_autocomplete' ) // Input var okay.
 		) {
 			wp_send_json_error( array(
-				'message' => 'Nonce field doens\'t match',
+				'message' => __( 'Nonce field doens\'t match.', 'wordlift' ),
 			) );
 		}
 
@@ -62,7 +62,7 @@ class Wordlift_Autocomplete_Adapter {
 			$query = sanitize_text_field( wp_unslash( $_REQUEST['query'] ) ); // Input var okay.
 		} else {
 			wp_send_json_error( array(
-				'message' => 'The query param is empty!',
+				'message' => __( 'The query param is empty.', 'wordlift' ),
 			) );
 		}
 
@@ -80,7 +80,7 @@ class Wordlift_Autocomplete_Adapter {
 			) );
 		} else {
 			// Default error message.
-			$error_message = __( 'Something went wrong.' );
+			$error_message = 'Something went wrong.';
 
 			// Get the real error message if there is WP_Error.
 			if ( is_wp_error( $response ) ) {
@@ -89,7 +89,7 @@ class Wordlift_Autocomplete_Adapter {
 
 			// There is an error, so send error message.
 			wp_send_json_error( array(
-				'message' => $error_message,
+				'message' => sprintf( esc_html__( '%s', 'wordlift' ), $error_message ),
 			) );
 		}
 	}

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -36,7 +36,7 @@ class Wordlift_Autocomplete_Adapter {
 	 *
 	 * @since 3.14.2
 	 *
-	 * @param \Wordlift_Autocomplete_Service $autocomplete_service
+	 * @param \Wordlift_Autocomplete_Service $autocomplete_service The {@link Wordlift_Autocomplete_Service} instance.
 	 */
 	public function __construct( $autocomplete_service ) {
 		$this->autocomplete_service = $autocomplete_service;
@@ -46,15 +46,13 @@ class Wordlift_Autocomplete_Adapter {
 	 * Handle the autocomplete ajax request.
 	 *
 	 * @since 3.15.0
-	 *
-	 * @return string The entity base path.
 	 */
 	public function wl_autocomplete() {
 		if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'wordlift_autocomplete' ) ) {
 			wp_send_json_error( array( 'message' => 'Nonce field doens\'t match' ) );
 		}
 
-		// Return 
+		// Return error if the query param si empty.
 		if ( empty( $_REQUEST['query'] ) ) {
 			wp_send_json_error( array( 'message' => 'The query param is empty!' ) );
 		}

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Wordlift_Autocomplete_Adapter class.
+ *
+ * The {@link Wordlift_Autocomplete_Adapter} class create requests to external API's.
+ *
+ * @link       https://wordlift.io
+ *
+ * @package    Wordlift
+ * @since      3.15.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Create autocomplete request to external API's and return the result if there is such.
+ *
+ * @since 3.15.0
+ */
+class Wordlift_Autocomplete_Adapter {
+
+	/**
+	 * The {@link Wordlift_Autocomplete_Service} instance.
+	 *
+	 * @since  3.15.0
+	 * @access private
+	 * @var \Wordlift_Autocomplete_Service $configuration_service The {@link Wordlift_Autocomplete_Service} instance.
+	 */
+	private $autocomplete_service;
+
+
+	/**
+	 * Wordlift_Autocomplete_Adapter constructor.
+	 *
+	 * @since 3.14.2
+	 *
+	 * @param \Wordlift_Autocomplete_Service $autocomplete_service
+	 */
+	public function __construct( $autocomplete_service ) {
+		$this->autocomplete_service = $autocomplete_service;
+	}
+
+	/**
+	 * Handle the autocomplete ajax request.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return string The entity base path.
+	 */
+	public function wl_autocomplete() {
+		if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'wordlift_autocomplete' ) ) {
+			wp_send_json_error( array( 'message' => 'Nonce field doens\'t match' ) );
+		}
+
+		// Return 
+		if ( empty( $_REQUEST['query'] ) ) {
+			wp_send_json_error( array( 'message' => 'The query param is empty!' ) );
+		}
+
+		// Make request.
+		$response = $this->autocomplete_service->make_request( $_REQUEST['query'] );
+		// Decode response body.
+		$suggestions = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		// Clear any buffer.
+		ob_clean();
+
+		// If the response is valid, then send the suggestions.
+		if ( ! is_wp_error( $response ) && 200 === (int) $response['response']['code'] ) {
+			// Echo the response.
+			wp_send_json_success( array( 'suggestions' => $suggestions ) );
+		} else {
+			// There is an error, so send error message.
+			wp_send_json_error( array( 'message' => __( 'Something went wrong.' ) ) );
+		}
+	}
+}

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -48,7 +48,10 @@ class Wordlift_Autocomplete_Adapter {
 	 * @since 3.15.0
 	 */
 	public function wl_autocomplete() {
-		if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' ) ) {
+		if (
+		    ! isset( $_REQUEST['_wpnonce'] ) ||
+		    ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'wordlift_autocomplete' )
+		) {
 			wp_send_json_error( array(
 				'message' => 'Nonce field doens\'t match',
 			) );

--- a/src/includes/class-wordlift-autocomplete-adapter.php
+++ b/src/includes/class-wordlift-autocomplete-adapter.php
@@ -90,7 +90,7 @@ class Wordlift_Autocomplete_Adapter {
 			// There is an error, so send error message.
 			wp_send_json_error( array(
 				/* translators: Placeholders: %s - the error message that will be returned. */
-				'message' => sprintf( esc_html__( '%s', 'wordlift' ), $error_message ),
+				'message' => sprintf( esc_html__( 'Error: %s', 'wordlift' ), $error_message ),
 			) );
 		}
 	}

--- a/src/includes/class-wordlift-autocomplete-service.php
+++ b/src/includes/class-wordlift-autocomplete-service.php
@@ -45,7 +45,7 @@ class Wordlift_Autocomplete_Service {
 	 *
 	 * @param \Wordlift_Configuration_Service $configuration_service The {@link Wordlift_Configuration_Service} instance.
 	 */
-	public function __construct ( $configuration_service ) {
+	public function __construct( $configuration_service ) {
 		$this->configuration_service = $configuration_service;
 		$this->log                   = Wordlift_Log_Service::get_logger( 'Wordlift_Autocomplete_Service' );
 	}
@@ -55,7 +55,7 @@ class Wordlift_Autocomplete_Service {
 	 *
 	 * @since 3.15.0
 	 *
-	 * @param string $query The search string
+	 * @param string $query The search string.
 	 *
 	 * @return array $response The API response.
 	 */
@@ -74,7 +74,7 @@ class Wordlift_Autocomplete_Service {
 	 *
 	 * @since 3.15.0
 	 *
-	 * @param string $query The search string
+	 * @param string $query The search string.
 	 *
 	 * @return string Builded url.
 	 */

--- a/src/includes/class-wordlift-autocomplete-service.php
+++ b/src/includes/class-wordlift-autocomplete-service.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Wordlift_Autocomplete_Service class.
+ *
+ * The {@link Wordlift_Autocomplete_Service} class handle and process all autocomplete requests.
+ *
+ * @link       https://wordlift.io
+ *
+ * @package    Wordlift
+ * @since      3.15.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Process WordLift's autocomplete requests.
+ *
+ * @since 3.15.0
+ */
+class Wordlift_Autocomplete_Service {
+	/**
+	 * The {@link Wordlift_Configuration_Service} instance.
+	 *
+	 * @since  3.15.0
+	 * @access private
+	 * @var \Wordlift_Configuration_Service $configuration_service The {@link Wordlift_Configuration_Service} instance.
+	 */
+	private $configuration_service;
+
+	/**
+	 * A {@link Wordlift_Log_Service} instance.
+	 *
+	 * @since  3.15.0
+	 * @access private
+	 * @var \Wordlift_Log_Service $log A {@link Wordlift_Log_Service} instance.
+	 */
+	private $log;
+
+	/**
+	 * The {@link Class_Wordlift_Autocomplete_Service} instance.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param \Wordlift_Configuration_Service $configuration_service The {@link Wordlift_Configuration_Service} instance.
+	 */
+	public function __construct ( $configuration_service ) {
+		$this->configuration_service = $configuration_service;
+		$this->log                   = Wordlift_Log_Service::get_logger( 'Wordlift_Autocomplete_Service' );
+	}
+
+	/**
+	 * Make request to external API and return the response.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param string $query The search string
+	 *
+	 * @return array $response The API response.
+	 */
+	public function make_request( $query ) {
+		$url = $this->build_request_url( $query );
+
+		// Make request.
+		$response = wp_remote_get( $url );
+
+		// Return the response.
+		return $response;
+	}
+
+	/**
+	 * Build the autocomplete url.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param string $query The search string
+	 *
+	 * @return string Builded url.
+	 */
+	public function build_request_url( $query ) {
+		$args = array(
+			'key'      => $this->configuration_service->get_key(),
+			'language' => $this->configuration_service->get_language_code(),
+			'query'    => $query,
+			'limit'    => 50,
+		);
+
+		// Add args to URL.
+		$request_url = add_query_arg(
+			$args,
+			$this->configuration_service->get_autocomplete_url()
+		);
+
+		// return the builded url.
+		return $request_url;
+	}
+}

--- a/src/includes/class-wordlift-autocomplete-service.php
+++ b/src/includes/class-wordlift-autocomplete-service.php
@@ -78,7 +78,7 @@ class Wordlift_Autocomplete_Service {
 	 *
 	 * @return string Built url.
 	 */
-	public function build_request_url( $query ) {
+	private function build_request_url( $query ) {
 		$args = array(
 			'key'      => $this->configuration_service->get_key(),
 			'language' => $this->configuration_service->get_language_code(),

--- a/src/includes/class-wordlift-autocomplete-service.php
+++ b/src/includes/class-wordlift-autocomplete-service.php
@@ -76,7 +76,7 @@ class Wordlift_Autocomplete_Service {
 	 *
 	 * @param string $query The search string.
 	 *
-	 * @return string Builded url.
+	 * @return string Built url.
 	 */
 	public function build_request_url( $query ) {
 		$args = array(
@@ -92,7 +92,7 @@ class Wordlift_Autocomplete_Service {
 			$this->configuration_service->get_autocomplete_url()
 		);
 
-		// return the builded url.
+		// return the built url.
 		return $request_url;
 	}
 }

--- a/src/includes/class-wordlift-configuration-service.php
+++ b/src/includes/class-wordlift-configuration-service.php
@@ -439,7 +439,7 @@ class Wordlift_Configuration_Service {
 	 */
 	public function get_autocomplete_url() {
 
-		return WL_CONFIG_WORDLIFT_API_URL_DEFAULT_VALUE . '/autocomplete';
+		return WL_CONFIG_WORDLIFT_API_URL_DEFAULT_VALUE . 'autocomplete';
 
 	}
 

--- a/src/includes/class-wordlift-configuration-service.php
+++ b/src/includes/class-wordlift-configuration-service.php
@@ -430,4 +430,17 @@ class Wordlift_Configuration_Service {
 
 	}
 
+	/**
+	 * Get the URL to perform autocomplete request.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return string The URL to call to perform the batch analyzes.
+	 */
+	public function get_autocomplete_url() {
+
+		return WL_CONFIG_WORDLIFT_API_URL_DEFAULT_VALUE . '/autocomplete';
+
+	}
+
 }

--- a/src/includes/class-wordlift.php
+++ b/src/includes/class-wordlift.php
@@ -589,6 +589,24 @@ class Wordlift {
 	protected $rendition_factory;
 
 	/**
+	 * The {@link Wordlift_Autocomplete_Service} instance.
+	 *
+	 * @since  3.15.0
+	 * @access private
+	 * @var \Wordlift_Autocomplete_Service $autocomplete_service The {@link Wordlift_Autocomplete_Service} instance.
+	 */
+	private $autocomplete_service;
+
+	/**
+	 * The {@link Wordlift_Autocomplete_Adapter} instance.
+	 *
+	 * @since  3.15.0
+	 * @access private
+	 * @var \Wordlift_Autocomplete_Adapter $autocomplete_adapter The {@link Wordlift_Autocomplete_Adapter} instance.
+	 */
+	private $autocomplete_adapter;
+
+	/**
 	 * The {@link Wordlift_Relation_Service} instance.
 	 *
 	 * @since  3.15.0
@@ -849,6 +867,10 @@ class Wordlift {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/wp-async-task/class-wordlift-batch-analysis-request-async-task.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/wp-async-task/class-wordlift-batch-analysis-complete-async-task.php';
 
+		/** Async Tasks. */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wordlift-autocomplete-service.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-wordlift-autocomplete-adapter.php';
+
 		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
@@ -1102,6 +1124,10 @@ class Wordlift {
 		new Wordlift_Batch_Analysis_Request_Async_Task();
 		new Wordlift_Batch_Analysis_Complete_Async_Task();
 
+		/** WL Autocomplete. */
+		$this->autocomplete_service = new Wordlift_Autocomplete_Service( $this->configuration_service );
+		$this->autocomplete_adapter = new Wordlift_Autocomplete_Adapter( $this->autocomplete_service );
+
 		/** WordPress Admin UI. */
 
 		// UI elements.
@@ -1307,6 +1333,10 @@ class Wordlift {
 
 		$this->loader->add_action( 'wp_ajax_wl_sample_data_create', $this->sample_data_ajax_adapter, 'create' );
 		$this->loader->add_action( 'wp_ajax_wl_sample_data_delete', $this->sample_data_ajax_adapter, 'delete' );
+
+		// Handle the autocomplete request.
+		add_action( 'wp_ajax_wl_autocomplete', array( $this->autocomplete_adapter, 'wl_autocomplete') );
+		add_action( 'wp_ajax_nopriv_wl_autocomplete', array( $this->autocomplete_adapter, 'wl_autocomplete') );
 
 		// Hooks to restrict multisite super admin from manipulating entity types.
 		if ( is_multisite() ) {

--- a/src/includes/class-wordlift.php
+++ b/src/includes/class-wordlift.php
@@ -1335,8 +1335,8 @@ class Wordlift {
 		$this->loader->add_action( 'wp_ajax_wl_sample_data_delete', $this->sample_data_ajax_adapter, 'delete' );
 
 		// Handle the autocomplete request.
-		add_action( 'wp_ajax_wl_autocomplete', array( $this->autocomplete_adapter, 'wl_autocomplete') );
-		add_action( 'wp_ajax_nopriv_wl_autocomplete', array( $this->autocomplete_adapter, 'wl_autocomplete') );
+		add_action( 'wp_ajax_wl_autocomplete', array( $this->autocomplete_adapter, 'wl_autocomplete' ) );
+		add_action( 'wp_ajax_nopriv_wl_autocomplete', array( $this->autocomplete_adapter, 'wl_autocomplete' ) );
 
 		// Hooks to restrict multisite super admin from manipulating entity types.
 		if ( is_multisite() ) {

--- a/tests/class-wordlift-ajax-unit-test-case.php
+++ b/tests/class-wordlift-ajax-unit-test-case.php
@@ -37,6 +37,12 @@ abstract class Wordlift_Ajax_Unit_Test_Case extends WP_Ajax_UnitTestCase {
 		// Configure WordPress with the test settings.
 		wl_configure_wordpress_test();
 
+		// Disable WordPress updates to avoid filtered wp_remote_* requests to
+		// WordPress' own servers to fail miserably.
+		remove_action( 'admin_init', '_maybe_update_core' );
+		remove_action( 'admin_init', '_maybe_update_plugins' );
+		remove_action( 'admin_init', '_maybe_update_themes' );
+
 		$this->entity_factory = new Wordlift_UnitTest_Factory_For_Entity( $this->factory );
 
 	}

--- a/tests/test-ajax-autocomplete.php
+++ b/tests/test-ajax-autocomplete.php
@@ -14,21 +14,6 @@
  * @package Wordlift
  */
 class Wordlift_Autocomplete_Test extends Wordlift_Ajax_Unit_Test_Case {
-	/**
-	 * A {@link Wordlift_Autocomplete_Service} instance.
-	 *
-	 * @since  3.15.0
-	 * @access private
-	 * @var \Wordlift_Autocomplete_Service $configuration_service A {@link Wordlift_Autocomplete_Service} instance.
-	 */
-	private $autocomplete_service;
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function setUp() {
-		parent::setUp();
-	}
 
 	public function test_autocomplete_without_nonce() {
 		$_POST['query'] = 'test';

--- a/tests/test-ajax-autocomplete.php
+++ b/tests/test-ajax-autocomplete.php
@@ -44,7 +44,7 @@ class Wordlift_Autocomplete_Test extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertFalse( $response->success );
 		$this->assertObjectHasAttribute( 'data', $response );
 		$this->assertObjectHasAttribute( 'message', $response->data );
-		$this->assertEquals( 'Nonce field doens\'t match', $response->data->message );
+		$this->assertEquals( 'Nonce field doens\'t match.', $response->data->message );
 	}
 
 	public function test_autocomplete_with_wrong_nonce() {
@@ -62,7 +62,7 @@ class Wordlift_Autocomplete_Test extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertFalse( $response->success );
 		$this->assertObjectHasAttribute( 'data', $response );
 		$this->assertObjectHasAttribute( 'message', $response->data );
-		$this->assertEquals( 'Nonce field doens\'t match', $response->data->message );
+		$this->assertEquals( 'Nonce field doens\'t match.', $response->data->message );
 	}
 
 	public function test_autocomplete_with_nonce_without_query_param() {
@@ -80,7 +80,7 @@ class Wordlift_Autocomplete_Test extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertFalse( $response->success );
 		$this->assertObjectHasAttribute( 'data', $response );
 		$this->assertObjectHasAttribute( 'message', $response->data );
-		$this->assertEquals( 'The query param is empty!', $response->data->message );
+		$this->assertEquals( 'The query param is empty.', $response->data->message );
 	}
 
 	public function test_autocomplete_with_nonce_with_empty_query_param() {
@@ -99,7 +99,7 @@ class Wordlift_Autocomplete_Test extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertFalse( $response->success );
 		$this->assertObjectHasAttribute( 'data', $response );
 		$this->assertObjectHasAttribute( 'message', $response->data );
-		$this->assertEquals( 'The query param is empty!', $response->data->message );
+		$this->assertEquals( 'The query param is empty.', $response->data->message );
 	}
 
 	public function test_autocomplete_error_status_code() {
@@ -120,7 +120,7 @@ class Wordlift_Autocomplete_Test extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertFalse( $response->success );
 		$this->assertObjectHasAttribute( 'data', $response );
 		$this->assertObjectHasAttribute( 'message', $response->data );
-		$this->assertEquals( 'Something went wrong.', $response->data->message );
+		$this->assertEquals( 'Error: Something went wrong.', $response->data->message );
 	}
 
 	public function test_autocomplete_wp_error() {
@@ -141,7 +141,7 @@ class Wordlift_Autocomplete_Test extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertFalse( $response->success );
 		$this->assertObjectHasAttribute( 'data', $response );
 		$this->assertObjectHasAttribute( 'message', $response->data );
-		$this->assertEquals( 'WP Error!', $response->data->message );
+		$this->assertEquals( 'Error: WP Error!', $response->data->message );
 	}
 
 

--- a/tests/test-ajax-autocomplete.php
+++ b/tests/test-ajax-autocomplete.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Tests: Ajax Autocomplete Test.
+ *
+ * @since   3.15.0
+ * @package Wordlift
+ */
+require_once 'functions.php';
+
+/**
+ * Class AjaxAutocompleteTest
+ * Extend Wordlift_Ajax_Unit_Test_Case
+ *
+ * @since   3.15.0
+ * @package Wordlift
+ */
+class AjaxAutocompleteTest extends Wordlift_Ajax_Unit_Test_Case {
+	/**
+	 * A {@link Wordlift_Configuration_Service} instance.
+	 *
+	 * @since  3.15.0
+	 * @access private
+	 * @var \Wordlift_Configuration_Service $configuration_service A {@link Wordlift_Configuration_Service} instance.
+	 */
+	private $configuration_service;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$wordlift = new Wordlift_Test();
+		$this->configuration_service = $wordlift->get_configuration_service();
+	}
+
+	public function test_autocomplete_without_nonce() {
+		// Spoof the nonce in the POST superglobal
+		$_POST['query'] = 'test';
+
+		try {
+			$this->_handleAjax( 'wl_autocomplete' );
+		} catch ( WPAjaxDieContinueException $e ) {}
+	 
+		$response = json_decode( $this->_last_response );
+
+
+		$this->assertInternalType( 'object', $response );
+		$this->assertObjectHasAttribute( 'success', $response );
+		$this->assertFalse( $response->success );
+		$this->assertObjectHasAttribute( 'data', $response );
+		$this->assertObjectHasAttribute( 'message', $response->data );
+		$this->assertEquals( 'Nonce field doens\'t match', $response->data->message );
+	}
+
+	public function test_autocomplete_with_nonce_without_query_param() {
+		// Spoof the nonce in the POST superglobal
+		$_POST['_wpnonce'] = wp_create_nonce( 'wordlift_autocomplete' );
+
+		try {
+			$this->_handleAjax( 'wl_autocomplete' );
+		} catch ( WPAjaxDieContinueException $e ) {}
+	 
+		$response = json_decode( $this->_last_response );
+
+		$this->assertInternalType( 'object', $response );
+		$this->assertObjectHasAttribute( 'success', $response );
+		$this->assertFalse( $response->success );
+		$this->assertObjectHasAttribute( 'data', $response );
+		$this->assertObjectHasAttribute( 'message', $response->data );
+		$this->assertEquals( 'The query param is empty!', $response->data->message );
+
+	}
+
+	public function test_autocomplete() {
+		// Spoof the nonce in the POST superglobal
+		$_POST['_wpnonce'] = wp_create_nonce( 'wordlift_autocomplete' );
+		$_POST['query']    = 'test';
+
+
+		try {
+			$this->_handleAjax( 'wl_autocomplete' );
+		} catch ( WPAjaxDieContinueException $e ) {}
+	 
+		$response = json_decode( $this->_last_response );
+
+		$this->assertInternalType( 'object', $response );
+		$this->assertObjectHasAttribute( 'success', $response );
+		$this->assertTrue( $response->success );
+		$this->assertObjectHasAttribute( 'data', $response );
+		$this->assertObjectHasAttribute( 'suggestions', $response->data );
+	}
+}

--- a/tests/test-ajax-autocomplete.php
+++ b/tests/test-ajax-autocomplete.php
@@ -5,37 +5,32 @@
  * @since   3.15.0
  * @package Wordlift
  */
-require_once 'functions.php';
 
 /**
- * Class AjaxAutocompleteTest
+ * Class Wordlift_Autocomplete_Test
  * Extend Wordlift_Ajax_Unit_Test_Case
  *
  * @since   3.15.0
  * @package Wordlift
  */
-class AjaxAutocompleteTest extends Wordlift_Ajax_Unit_Test_Case {
+class Wordlift_Autocomplete_Test extends Wordlift_Ajax_Unit_Test_Case {
 	/**
-	 * A {@link Wordlift_Configuration_Service} instance.
+	 * A {@link Wordlift_Autocomplete_Service} instance.
 	 *
 	 * @since  3.15.0
 	 * @access private
-	 * @var \Wordlift_Configuration_Service $configuration_service A {@link Wordlift_Configuration_Service} instance.
+	 * @var \Wordlift_Autocomplete_Service $configuration_service A {@link Wordlift_Autocomplete_Service} instance.
 	 */
-	private $configuration_service;
+	private $autocomplete_service;
 
 	/**
 	 * {@inheritdoc}
 	 */
 	public function setUp() {
 		parent::setUp();
-
-		$wordlift = new Wordlift_Test();
-		$this->configuration_service = $wordlift->get_configuration_service();
 	}
 
 	public function test_autocomplete_without_nonce() {
-		// Spoof the nonce in the POST superglobal
 		$_POST['query'] = 'test';
 
 		try {
@@ -44,6 +39,23 @@ class AjaxAutocompleteTest extends Wordlift_Ajax_Unit_Test_Case {
 	 
 		$response = json_decode( $this->_last_response );
 
+		$this->assertInternalType( 'object', $response );
+		$this->assertObjectHasAttribute( 'success', $response );
+		$this->assertFalse( $response->success );
+		$this->assertObjectHasAttribute( 'data', $response );
+		$this->assertObjectHasAttribute( 'message', $response->data );
+		$this->assertEquals( 'Nonce field doens\'t match', $response->data->message );
+	}
+
+	public function test_autocomplete_with_wrong_nonce() {
+		$_POST['_wpnonce'] = wp_create_nonce( 'wrong_nonce' );
+		$_POST['query']    = 'test';
+
+		try {
+			$this->_handleAjax( 'wl_autocomplete' );
+		} catch ( WPAjaxDieContinueException $e ) {}
+
+		$response = json_decode( $this->_last_response );
 
 		$this->assertInternalType( 'object', $response );
 		$this->assertObjectHasAttribute( 'success', $response );
@@ -60,7 +72,7 @@ class AjaxAutocompleteTest extends Wordlift_Ajax_Unit_Test_Case {
 		try {
 			$this->_handleAjax( 'wl_autocomplete' );
 		} catch ( WPAjaxDieContinueException $e ) {}
-	 
+
 		$response = json_decode( $this->_last_response );
 
 		$this->assertInternalType( 'object', $response );
@@ -69,25 +81,80 @@ class AjaxAutocompleteTest extends Wordlift_Ajax_Unit_Test_Case {
 		$this->assertObjectHasAttribute( 'data', $response );
 		$this->assertObjectHasAttribute( 'message', $response->data );
 		$this->assertEquals( 'The query param is empty!', $response->data->message );
-
 	}
 
-	public function test_autocomplete() {
+	public function test_autocomplete_with_nonce_with_empty_query_param() {
 		// Spoof the nonce in the POST superglobal
 		$_POST['_wpnonce'] = wp_create_nonce( 'wordlift_autocomplete' );
-		$_POST['query']    = 'test';
-
+		$_POST['query']    = '';
 
 		try {
 			$this->_handleAjax( 'wl_autocomplete' );
 		} catch ( WPAjaxDieContinueException $e ) {}
-	 
+
 		$response = json_decode( $this->_last_response );
 
 		$this->assertInternalType( 'object', $response );
 		$this->assertObjectHasAttribute( 'success', $response );
-		$this->assertTrue( $response->success );
+		$this->assertFalse( $response->success );
 		$this->assertObjectHasAttribute( 'data', $response );
-		$this->assertObjectHasAttribute( 'suggestions', $response->data );
+		$this->assertObjectHasAttribute( 'message', $response->data );
+		$this->assertEquals( 'The query param is empty!', $response->data->message );
 	}
+
+	public function test_autocomplete_error_status_code() {
+		// Spoof the nonce in the POST superglobal
+		$_POST['_wpnonce'] = wp_create_nonce( 'wordlift_autocomplete' );
+		$_POST['query']    = 'test';
+
+		add_filter( 'pre_http_request', array( $this, 'return_error_code' ), 100 );
+
+		try {
+			$this->_handleAjax( 'wl_autocomplete' );
+		} catch ( WPAjaxDieContinueException $e ) {}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertInternalType( 'object', $response );
+		$this->assertObjectHasAttribute( 'success', $response );
+		$this->assertFalse( $response->success );
+		$this->assertObjectHasAttribute( 'data', $response );
+		$this->assertObjectHasAttribute( 'message', $response->data );
+		$this->assertEquals( 'Something went wrong.', $response->data->message );
+	}
+
+	public function test_autocomplete_wp_error() {
+		// Spoof the nonce in the POST superglobal
+		$_POST['_wpnonce'] = wp_create_nonce( 'wordlift_autocomplete' );
+		$_POST['query']    = 'test';
+
+		add_filter( 'pre_http_request', array( $this, 'return_wp_error' ), 100 );
+
+		try {
+			$this->_handleAjax( 'wl_autocomplete' );
+		} catch ( WPAjaxDieContinueException $e ) {}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertInternalType( 'object', $response );
+		$this->assertObjectHasAttribute( 'success', $response );
+		$this->assertFalse( $response->success );
+		$this->assertObjectHasAttribute( 'data', $response );
+		$this->assertObjectHasAttribute( 'message', $response->data );
+		$this->assertEquals( 'WP Error!', $response->data->message );
+	}
+
+
+	public function return_wp_error() {
+		return new WP_Error( 'broke', 'WP Error!' );
+	}
+
+	public function return_error_code() {
+		return array(
+			'response' => array(
+				'code' => 404,
+			),
+		);
+	}
+
 }

--- a/tests/test-content-filter-service.php
+++ b/tests/test-content-filter-service.php
@@ -106,7 +106,7 @@ class Wordlift_Content_Filter_Service_Test extends Wordlift_Unit_Test_Case {
 		$content = '<span id="urn:enhancement-4b54b56d-7142-5dd3-adc6-27e51c70fdad" class="textannotation disambiguated wl-person" itemid="http://data.example.org/entity">Matt Mullenweg</span> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
 
 		// The expected content with a link.
-		$expected = '<a class=\'wl-entity-page-link\' href=\'http://example.org/link\'>Matt Mullenweg</a> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
+		$expected = '<a class=\'wl-entity-page-link\'  href=\'http://example.org/link\'>Matt Mullenweg</a> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
 
 		// Check that the expected content matches the function output.
 		$this->assertEquals( $expected, $this->content_filter_service->the_content( $content ) );
@@ -289,7 +289,7 @@ class Wordlift_Content_Filter_Service_Test extends Wordlift_Unit_Test_Case {
 		$content = '<span id="urn:enhancement-4b54b56d-7142-5dd3-adc6-27e51c70fdad" class="textannotation wl-link disambiguated wl-person" itemid="http://data.example.org/entity">Matt Mullenweg</span> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
 
 		// The expected content with a link.
-		$expected = '<a class=\'wl-entity-page-link\' href=\'http://example.org/link\'>Matt Mullenweg</a> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
+		$expected = '<a class=\'wl-entity-page-link\'  href=\'http://example.org/link\'>Matt Mullenweg</a> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
 
 		// Check that the expected content matches the function output.
 		$this->assertEquals( $expected, $this->content_filter_service->the_content( $content ) );
@@ -312,7 +312,7 @@ class Wordlift_Content_Filter_Service_Test extends Wordlift_Unit_Test_Case {
 		$content = '<span id="urn:enhancement-4b54b56d-7142-5dd3-adc6-27e51c70fdad" class="textannotation wl-link disambiguated wl-person" itemid="http://data.example.org/entity">Matt Mullenweg</span> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
 
 		// The expected content with a link.
-		$expected = '<a class=\'wl-entity-page-link\' href=\'http://example.org/link\'>Matt Mullenweg</a> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
+		$expected = '<a class=\'wl-entity-page-link\'  href=\'http://example.org/link\'>Matt Mullenweg</a> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
 
 		// Check that the expected content matches the function output.
 		$this->assertEquals( $expected, $this->content_filter_service->the_content( $content ) );
@@ -335,7 +335,7 @@ class Wordlift_Content_Filter_Service_Test extends Wordlift_Unit_Test_Case {
 		$content = '<span id="urn:enhancement-4b54b56d-7142-5dd3-adc6-27e51c70fdad" class="textannotation disambiguated wl-person" itemid="http://data.example.org/entity">Matt Mullenweg</span> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
 
 		// The expected content with a link.
-		$expected = '<a class=\'wl-entity-page-link\' href=\'http://example.org/link\'>Matt Mullenweg</a> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
+		$expected = '<a class=\'wl-entity-page-link\'  href=\'http://example.org/link\'>Matt Mullenweg</a> would love to see what we\'re achieving with WordLift for <span id="urn:enhancement-7aa39603-d48f-8ac8-5437-c74b3b0e28ef" class="textannotation">WordPress</span>!';
 
 		// Check that the expected content matches the function output.
 		$this->assertEquals( $expected, $this->content_filter_service->the_content( $content ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
 * Introduce Autocomplete API

As explained in #607 we need to create autocomplete API that will handle all requests from wp-admin (wp_ajax_) and create additional request to external sources to retrieve the suggestions. The autocomplete feature is still not implement, but it will be soon in #608 .

Currently it's not possible to test, due to `wp_nonce`, it will be when we add nonce field in the admin.

#### Testing instructions:

* Activate the plugin and add your API key
* Since the widget is not in the main branch yet, you should use some app to make a request ( I am using [Postman](https://www.getpostman.com/) ), but you can use any app that allow you to create sample request.
* Make a request and add the following params:
`action: wl_autocomplete`
`query: the search term you are looking for `

You should receive JSON data ready to use.

#### TODO:
* Add nonce field in Autocomplete form widget