### PR TITLE
Feature 488: Make all download data downloadable

### DIFF
--- a/src/admin/class-wordlift-download-your-data-page.php
+++ b/src/admin/class-wordlift-download-your-data-page.php
@@ -90,10 +90,11 @@ class Wordlift_Admin_Download_Your_Data_Page {
 		if ( ! is_wp_error( $response ) && 200 === (int) $response['response']['code'] ) {
 			// Get response body.
 			$body = wp_remote_retrieve_body( $response );
+			$type = wp_remote_retrieve_header( $response, 'content-type' );
 
 			// Add proper file headers.
-			header( 'Content-Disposition: attachment; filename=' . $filename );
-			header( 'Content-Type: application/octet-stream; charset=' . get_bloginfo( 'charset' ) );
+			header( "Content-Disposition: attachment; filename=$filename" );
+			header( "Content-Type: $type" );
 
 			// Echo the response body.
 			echo $body; // WPCS: XSS OK.

--- a/src/admin/class-wordlift-download-your-data-page.php
+++ b/src/admin/class-wordlift-download-your-data-page.php
@@ -68,7 +68,10 @@ class Wordlift_Admin_Download_Your_Data_Page {
 	 */
 	public function download_your_data() {
 
-		ob_end_clean();
+		// Avoid PHP notices when buffer is empty.
+		if ( ob_get_contents() ) {
+			ob_end_clean();
+		}
 
 		// Get WL's key.
 		$key = $this->configuration_service->get_key();
@@ -85,7 +88,7 @@ class Wordlift_Admin_Download_Your_Data_Page {
 		$filename = 'dataset.' . $suffix;
 
 		// Make the request.
-		$response = wp_remote_get( WL_CONFIG_WORDLIFT_API_URL_DEFAULT_VALUE . "datasets/key=$key/$filename" );
+		$response = wp_safe_remote_get( WL_CONFIG_WORDLIFT_API_URL_DEFAULT_VALUE . "datasets/key=$key/$filename" );
 
 		if ( ! is_wp_error( $response ) && 200 === (int) $response['response']['code'] ) {
 			// Get response body.
@@ -96,7 +99,10 @@ class Wordlift_Admin_Download_Your_Data_Page {
 			header( "Content-Disposition: attachment; filename=$filename" );
 			header( "Content-Type: $type" );
 
-			// Echo the response body.
+			/*
+			 * Echo the response body. As this is not HTML we can not escape it
+			 * and neither sanitize it, therefor turning off the linter notice.
+			 */
 			echo $body; // WPCS: XSS OK.
 		} else {
 			// Something is not working properly, so display error message.

--- a/src/admin/class-wordlift-download-your-data-page.php
+++ b/src/admin/class-wordlift-download-your-data-page.php
@@ -17,15 +17,17 @@
  */
 class Wordlift_Admin_Download_Your_Data_Page {
 	/**
-	 * Allowed types.
+	 * Used to check if the requested file is supported.
 	 *
 	 * @since  3.16.0
 	 * @access private
-	 * @var $allowed_types array Allowed types.
+	 * @var $allowed_formats array Allowed formats.
 	 */
-	private $allowed_types = array(
-		'application/json;charset=UTF-8',
-		'application/rdf+xml;charset=UTF-8',
+	private $allowed_formats = array(
+		'json',
+		'rdf',
+		'ttl',
+		'n3',
 	);
 
 	/**
@@ -98,6 +100,11 @@ class Wordlift_Admin_Download_Your_Data_Page {
 		// Create filename.
 		$filename = 'dataset.' . $suffix;
 
+		if ( ! in_array( $suffix, $this->allowed_formats, true ) ) {
+			// The file type is not from allowed types.
+			wp_die( esc_html__( 'The format is not supported.', 'wordlift' ) );
+		}
+
 		// Make the request.
 		$response = wp_safe_remote_get( WL_CONFIG_WORDLIFT_API_URL_DEFAULT_VALUE . "datasets/key=$key/$filename" );
 
@@ -113,11 +120,6 @@ class Wordlift_Admin_Download_Your_Data_Page {
 		$body     = wp_remote_retrieve_body( $response );
 		$type     = wp_remote_retrieve_header( $response, 'content-type' );
 		$filename = 'dataset-' . date( 'Y-m-d-H-i-s' ) . '.' . $suffix;
-
-		if ( ! in_array( $type, $this->allowed_types, true ) ) {
-			// The file type is not from allowed types.
-			wp_die( esc_html__( 'The server responds, but this file type is not permitted for security reasons.', 'wordlift' ) );
-		}
 
 		// Add proper file headers.
 		header( "Content-Disposition: attachment; filename=$filename" );


### PR DESCRIPTION
Fixes #488 

Currently when you hit the download button on "Download your data" page in some cases you are redirected to the source, where you can copy your data. 
In this PR this issue is addressed and now all buttons will download a file, instead opening the content.

The only thing that I am not sure here is the content type. Currently it's hadrcoded to `application/octet-stream`, but I don't think that we will have different types for now. We can easy address this by using `get_mime_type` or `file_mime_type`