### PR TITLE
Feature 597: Crop publisher logo to recommended dimensions

### DIFF
--- a/src/admin/wordlift_admin.php
+++ b/src/admin/wordlift_admin.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * This file contains miscellaneous admin-functions.
+ *
+ * @package Wordlift
  */
 
 // Add the Admin menu.
@@ -16,18 +18,17 @@ require_once( 'wordlift_admin_menu.php' );
 function wl_serialize_entity( $entity ) {
 
 	$entity = ( is_numeric( $entity ) ) ? get_post( $entity ) : $entity;
-	
 	$type   = wl_entity_type_taxonomy_get_type( $entity->ID );
 	$images = wl_get_image_urls( $entity->ID );
 
 	return array(
-		'id'         	=> wl_get_entity_uri( $entity->ID ),
-		'label'      	=> $entity->post_title,
-		'description'	=> $entity->post_content,
-		'sameAs'     	=> wl_schema_get_value( $entity->ID, 'sameAs' ),
-		'mainType'      => str_replace( 'wl-', '', $type['css_class'] ),
-		'types'      	=> wl_get_entity_rdf_types( $entity->ID ),
-		'images' 		=> $images,
+		'id'          => wl_get_entity_uri( $entity->ID ),
+		'label'       => $entity->post_title,
+		'description' => $entity->post_content,
+		'sameAs'      => wl_schema_get_value( $entity->ID, 'sameAs' ),
+		'mainType'    => str_replace( 'wl-', '', $type['css_class'] ),
+		'types'       => wl_get_entity_rdf_types( $entity->ID ),
+		'images'      => $images,
 
 	);
 }
@@ -45,18 +46,18 @@ function wl_remove_text_annotations( $data ) {
 
 	// Remove blank elements that can interfere with annoataions removing
 	// See https://github.com/insideout10/wordlift-plugin/issues/234
-	// Just blank attributes without any attribtues are cleaned up
+	// Just blank attributes without any attribtues are cleaned up.
 	$pattern = '/<(\w+)><\/\1>/im';
 	// Remove the pattern while it is found (match nested annotations).
-	while ( 1 === preg_match( $pattern, $data['post_content'] ) ) {		
-		$data['post_content'] = preg_replace( $pattern, '$2', $data['post_content'], -1, $count ); 
+	while ( 1 === preg_match( $pattern, $data['post_content'] ) ) {
+		$data['post_content'] = preg_replace( $pattern, '$2', $data['post_content'], -1, $count );
 	}
 	// Remove text annotations
-	//    <span class="textannotation" id="urn:enhancement-777cbed4-b131-00fb-54a4-ed9b26ae57ea">
+	// <span class="textannotation" id="urn:enhancement-777cbed4-b131-00fb-54a4-ed9b26ae57ea">.
 	$pattern = '/<(\w+)[^>]*\sclass=\\\"textannotation(?![^\\"]*\sdisambiguated)[^\\"]*\\\"[^>]*>([^<]+)<\/\1>/im';
 	// Remove the pattern while it is found (match nested annotations).
-	while ( 1 === preg_match( $pattern, $data['post_content'] ) ) {		
-		$data['post_content'] = preg_replace( $pattern, '$2', $data['post_content'], -1, $count ); 
+	while ( 1 === preg_match( $pattern, $data['post_content'] ) ) {
+		$data['post_content'] = preg_replace( $pattern, '$2', $data['post_content'], -1, $count );
 	}
 	return $data;
 }
@@ -72,8 +73,7 @@ add_filter( 'wp_insert_post_data', 'wl_remove_text_annotations', '98', 1 );
  *
  * @return array The updated list of CSS classes.
  */
-function wl_admin_metaboxes_add_css_class( $classes = array() ){
-	
+function wl_admin_metaboxes_add_css_class( $classes = array() ) {
 	return array_merge( $classes, array( 'wl-metabox' ) );
 }
 

--- a/src/admin/wordlift_admin.php
+++ b/src/admin/wordlift_admin.php
@@ -76,3 +76,60 @@ function wl_admin_metaboxes_add_css_class( $classes = array() ){
 	
 	return array_merge( $classes, array( 'wl-metabox' ) );
 }
+
+/**
+ * Adds new image size `wl_logo`. It will be used to crop & resize
+ * featured images of entity type "Oraganization".
+ * see: https://github.com/insideout10/wordlift-plugin/issues/597
+ *
+ * @since 3.16.0
+ *
+ * @return void
+ */
+function wl_after_setup_theme() {
+	// Add new image size for organization featured images.
+	add_image_size( 'wl_organization_logo', 600, 60, true );
+}
+
+add_action( 'after_setup_theme', 'wl_after_setup_theme' );
+
+/**
+ * Adds featured image metabox additional instructions
+ * when the entity type is organization.
+ * see: https://github.com/insideout10/wordlift-plugin/issues/597
+ *
+ * @since  3.16.0
+ *
+ * @param  string $content Current metabox content.
+ *
+ * @return string $content metabox content with additional instructions.
+ */
+function wl_add_featured_image_instruction( $content ) {
+	// Get the current post ID.
+	$post_id = get_the_ID();
+
+	// Bail if for some reason the post id is not set.
+	if ( empty( $post_id ) ) {
+		return $content;
+	}
+
+	// Get entity type(s).
+	$terms = wp_get_object_terms(
+		$post_id, // The post ID.
+		Wordlift_Entity_Types_Taxonomy_Service::TAXONOMY_NAME, // The taxonomy slug.
+		array(
+			'fields' => 'slugs', // We don't need all fields, but only slugs.
+		)
+	);
+
+	// Check that the entity type is "Organization".
+	if ( in_array( 'organization' , $terms, true ) ) {
+		// Add the featured image description when the type is "Organization".
+		$content .= '<p>' . esc_html__( 'Recommended image size 600px * 60px. Bigger images will be automatically cropped and resized to fit that size.', 'wordlift' ) . '</p>';
+	}
+
+	// Finally return the content.
+	return $content;
+}
+
+add_filter( 'admin_post_thumbnail_html', 'wl_add_featured_image_instruction' );

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -243,7 +243,7 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 		}
 
 		// Get the image URL.
-		if ( false === $attachment = wp_get_attachment_image_src( $thumbnail_id, 'full' ) ) {
+		if ( false === $attachment = wp_get_attachment_image_src( $thumbnail_id, 'wl_organization_logo' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes: #597 

Currently in JSON_LD for publisher logo is used "full" image size, which is wrong.
As @cyberandy mentioned in #597 the image size should fall in 600px (width) * 60px (height) range. 
This PR adds the `wl_organization_logo` image size that will crop the image. It seems that if the images is smaller than the required size, Google is still satisfied.

![image](https://cldup.com/fjLo8tF41t.thumb.png) 

There is another addition that will add more text below featured image box, when the type is organization:

![image2](https://cldup.com/Y7m98tNQ_f.thumb.png) 

