### PR TITLE
Feature 644: Remove empty referenced entities ids, to prevent fatal JS еrrors

### DIFF
--- a/src/admin/wordlift_admin_meta_box_entities.php
+++ b/src/admin/wordlift_admin_meta_box_entities.php
@@ -1,19 +1,19 @@
 <?php
-
 /**
  * This file provides methods and functions to generate entities meta-boxes in the admin UI.
+ *
+ * @package Wordlift
  */
-
 
 /**
  * Build WL_Metabox and the contained WL_Metabox_Field(s)
  */
 function wl_register_metaboxes() {
 
-	// Load metabox classes
+	// Load metabox classes.
 	require_once( 'WL_Metabox/class-wl-metabox.php' );
 
-	$wl_metabox = new WL_Metabox();     // Everything is done inside here with the correct timing
+	$wl_metabox = new WL_Metabox();     // Everything is done inside here with the correct timing.
 }
 
 if ( is_admin() ) {
@@ -29,9 +29,7 @@ if ( is_admin() ) {
  */
 function wl_admin_add_entities_meta_box( $post_type ) {
 
-	// wl_write_log( "wl_admin_add_entities_meta_box [ post type :: $post_type ]" );
-
-	// Add main meta box for related entities and 4W
+	// Add main meta box for related entities and 4W.
 	add_meta_box(
 		'wordlift_entities_box', __( 'WordLift', 'wordlift' ), 'wl_entities_box_content', $post_type, 'side', 'high'
 	);
@@ -46,42 +44,20 @@ add_action( 'add_meta_boxes', 'wl_admin_add_entities_meta_box' );
  */
 function wl_entities_box_content( $post ) {
 
-	// wl_write_log( "wl_entities_box_content [ post id :: $post->ID ]" );
-
-	// Angularjs edit-post widget wrapper
+	// Angularjs edit-post widget wrapper.
 	echo '<div id="wordlift-edit-post-outer-wrapper"></div>';
 
-	// Angularjs edit-post widget classification boxes configuration
+	// Angularjs edit-post widget classification boxes configuration.
 	$classification_boxes = unserialize( WL_CORE_POST_CLASSIFICATION_BOXES );
 
-	// Array to store all related entities ids
+	// Array to store all related entities ids.
 	$all_referenced_entities_ids = array();
 
-	// Add selected entities to classification_boxes
+	// Add selected entities to classification_boxes.
 	foreach ( $classification_boxes as $i => $box ) {
-		// Build the proper relation name
+		// Build the proper relation name.
 		$relation_name = $box['id'];
 
-		// wl_write_log( "Going to related of $relation_name" );
-//
-//		// Get entity ids related to the current post for the given relation name (both draft and published entities)
-//		$draft_entity_ids   = wl_core_get_related_entity_ids( $post->ID, array(
-//			'predicate' => $relation_name,
-//			'status'    => 'draft',
-//		) );
-//		$publish_entity_ids = wl_core_get_related_entity_ids( $post->ID, array(
-//			'predicate' => $relation_name,
-//			'status'    => 'publish',
-//		) );
-//		$entity_ids         = array_unique( array_merge( $draft_entity_ids, $publish_entity_ids ) );
-
-
-//		// Transform entity ids array in entity uris array
-//		array_walk( $entity_ids, function ( &$entity_id ) {
-//			// Retrieve the entity uri for the given entity id
-//			$entity_id = wl_get_entity_uri( $entity_id );
-//		} );
-//
 		// Get the entity referenced from the post content.
 		$entity_uris = Wordlift_Content_Filter_Service::get_instance()->get_entity_uris( $post->post_content );
 
@@ -98,20 +74,20 @@ function wl_entities_box_content( $post ) {
 				return $post->ID;
 			}
 		}, $entity_uris );
-		// Store the entity ids for all the 4W
+		// Store the entity ids for all the 4W.
 		$all_referenced_entities_ids = array_merge( $all_referenced_entities_ids, $entity_ids );
 
 		// Remove all null, false and empty strings.
 		$all_referenced_entities_ids = array_filter( $all_referenced_entities_ids );
 
 	}
-	// Json encoding for classification boxes structure
-	$classification_boxes = json_encode( $classification_boxes );
+	// Json encoding for classification boxes structure.
+	$classification_boxes = wp_json_encode( $classification_boxes );
 
-	// Ensure there are no repetitions of the referenced entities
+	// Ensure there are no repetitions of the referenced entities.
 	$all_referenced_entities_ids = array_unique( $all_referenced_entities_ids );
 
-	// Build the entity storage object
+	// Build the entity storage object.
 	$referenced_entities_obj = array();
 	foreach ( $all_referenced_entities_ids as $referenced_entity ) {
 		$entity                                   = wl_serialize_entity( $referenced_entity );
@@ -119,20 +95,20 @@ function wl_entities_box_content( $post ) {
 	}
 
 	$referenced_entities_obj = empty( $referenced_entities_obj ) ?
-		'{}' : json_encode( $referenced_entities_obj );
+		'{}' : wp_json_encode( $referenced_entities_obj );
 
 	$published_place_id  = get_post_meta(
 		$post->ID, Wordlift_Schema_Service::FIELD_LOCATION_CREATED, true
 	);
 	$published_place_obj = ( $published_place_id ) ?
-		json_encode( wl_serialize_entity( $published_place_id ) ) :
+		wp_json_encode( wl_serialize_entity( $published_place_id ) ) :
 		'undefined';
 
 	$topic_id  = get_post_meta(
 		$post->ID, Wordlift_Schema_Service::FIELD_TOPIC, true
 	);
 	$topic_obj = ( $topic_id ) ?
-		json_encode( wl_serialize_entity( $topic_id ) ) :
+		wp_json_encode( wl_serialize_entity( $topic_id ) ) :
 		'undefined';
 
 	$configuration_service = Wordlift_Configuration_Service::get_instance();
@@ -142,11 +118,11 @@ function wl_entities_box_content( $post ) {
 	$dataset_uri            = $configuration_service->get_dataset_uri();
 	$current_post_uri       = wl_get_entity_uri( $post->ID );
 
-	// Retrieve the current post author
+	// Retrieve the current post author.
 	$post_author = get_userdata( $post->post_author )->display_name;
-	// Retrive the published date
+	// Retrive the published date.
 	$published_date = get_the_time( 'Y-m-d', $post->ID );
-	// Current language
+	// Current language.
 	$current_language = $configuration_service->get_language_code();
 
 	echo <<<EOF

--- a/src/admin/wordlift_admin_meta_box_entities.php
+++ b/src/admin/wordlift_admin_meta_box_entities.php
@@ -93,10 +93,16 @@ function wl_entities_box_content( $post ) {
 		$entity_ids     = array_map( function ( $item ) use ( $entity_service ) {
 			$post = $entity_service->get_entity_post_by_uri( $item );
 
-			return $post->ID;
+			// Check that the post object is not null.
+			if ( ! empty( $post->ID ) ) {
+				return $post->ID;
+			}
 		}, $entity_uris );
 		// Store the entity ids for all the 4W
 		$all_referenced_entities_ids = array_merge( $all_referenced_entities_ids, $entity_ids );
+
+		// Remove all null, false and empty strings.
+		$all_referenced_entities_ids = array_filter( $all_referenced_entities_ids );
 
 	}
 	// Json encoding for classification boxes structure


### PR DESCRIPTION
Fixes #644 

Currently if there is annotation, but the entity is trashed, fatal js error is generated and it prevent annotations from being displayed.

There are two problems right now:
When the entity is in trash, [Entity service](https://github.com/insideout10/wordlift-plugin/blob/develop/src/includes/class-wordlift-entity-service.php#L281) return null, which generate the following error:

![php-error](https://cldup.com/gN8n-cP9Ts-3000x3000.png)

And then when the entity is serialized, the reference_entity is null, which generate the js error, that prevent the complete code execution and displaying all entities.

![js-error](https://cldup.com/IgOU3BTll1.png)