### PR TITLE
Hotfix 647: remove duplicates from related posts

### DIFF
--- a/src/includes/class-wordlift-relation-service.php
+++ b/src/includes/class-wordlift-relation-service.php
@@ -91,7 +91,7 @@ class Wordlift_Relation_Service {
 
 		$sql =
 			"
-			SELECT p.$actual_fields
+			SELECT DISTINCT p.$actual_fields
 			FROM {$this->relation_table} r
 			INNER JOIN $wpdb->posts p
 				ON p.id = r.subject_id


### PR DESCRIPTION
Fixes: #647 

Adding a "DISTINCT" clause to [Relation Services](https://github.com/insideout10/wordlift-plugin/blob/develop/src/includes/class-wordlift-relation-service.php#L84) solve the problem and remove the duplicate posts.