### PR TITLE
Feature 726: Set post type to Batch Analysis Service

### DIFF
--- a/src/includes/class-wordlift-batch-analysis-adapter.php
+++ b/src/includes/class-wordlift-batch-analysis-adapter.php
@@ -46,6 +46,9 @@ class Wordlift_Batch_Analysis_Adapter {
 			wp_die( 'The `link` parameter is required.' );
 		}
 
+		// Check whether the post type was added and sets the analysis post type.
+		$this->maybe_set_analysis_post_type();
+
 		$count = $this->batch_analysis_service->submit_auto_selected_posts( $_REQUEST['link'] );
 
 		// Clear any buffer.
@@ -67,6 +70,9 @@ class Wordlift_Batch_Analysis_Adapter {
 			wp_die( 'The `link` parameter is required.' );
 		}
 
+		// Check whether the post type was added and sets the analysis post type.
+		$this->maybe_set_analysis_post_type();
+
 		$count = $this->batch_analysis_service->submit_all_posts( $_REQUEST['link'] );
 
 		// Clear any buffer.
@@ -87,6 +93,9 @@ class Wordlift_Batch_Analysis_Adapter {
 		if ( ! isset( $_REQUEST['link'] ) || ! isset( $_REQUEST['post'] ) ) {
 			wp_die( 'The `link` and `post` parameters are required.' );
 		}
+
+		// Check whether the post type was added and sets the analysis post type.
+		$this->maybe_set_analysis_post_type();
 
 		$count = $this->batch_analysis_service->submit( (array) $_REQUEST['post'], $_REQUEST['link'] );
 
@@ -138,6 +147,17 @@ class Wordlift_Batch_Analysis_Adapter {
 		// Send the response.
 		wp_send_json_success();
 
+	}
+
+	/**
+	 * Set the analysis post type if the param is set in the request
+	 *
+	 * @since 3.17.0
+	 */
+	public function maybe_set_analysis_post_type() {
+		if ( isset( $_REQUEST['post_type'] ) ) {
+			$this->batch_analysis_service->set_post_type( $_REQUEST['post_type'] );
+		}
 	}
 
 }

--- a/src/includes/class-wordlift-batch-analysis-service.php
+++ b/src/includes/class-wordlift-batch-analysis-service.php
@@ -154,6 +154,15 @@ class Wordlift_Batch_Analysis_Service {
 	private $log;
 
 	/**
+	 * Post type to be analysed.
+	 *
+	 * @since  3.17.0
+	 * @access private
+	 * @var string $post_type Post type to be analyzed.
+	 */
+	private $post_type;
+
+	/**
 	 * The {@link Class_Wordlift_Batch_Analys_Service} instance.
 	 *
 	 * @since 3.14.0
@@ -215,14 +224,15 @@ class Wordlift_Batch_Analysis_Service {
 			LEFT JOIN $wpdb->postmeta batch_analysis_state
 				ON batch_analysis_state.post_id = p.ID
 					AND batch_analysis_state.meta_key = %s
-			WHERE p.post_type IN ('post', 'page')
+			WHERE p.post_type = %s
 				AND p.post_status = 'publish'
 			",
 			self::STATE_META_KEY,
 			self::SUBMIT_TIMESTAMP_META_KEY,
 			self::LINK_META_KEY,
 			$link,
-			self::STATE_META_KEY
+			self::STATE_META_KEY,
+			$this->get_post_type()
 		);
 	}
 
@@ -355,6 +365,7 @@ class Wordlift_Batch_Analysis_Service {
 			'meta_key'   => self::STATE_META_KEY,
 			'meta_value' => self::STATE_SUBMIT,
 			'orderby'    => 'ID',
+			'post_type'  => 'any', // Add any because posts from multiple posts types may be waiting.
 		) );
 
 		// Bail out if there are no submitted posts.
@@ -408,6 +419,7 @@ class Wordlift_Batch_Analysis_Service {
 			'meta_key'   => self::STATE_META_KEY,
 			'meta_value' => self::STATE_REQUEST,
 			'orderby'    => 'ID',
+			'post_type'  => 'any', // Add any because posts from multiple posts types may be waiting.
 		) );
 
 		// Bail out if there are no submitted posts.
@@ -607,6 +619,7 @@ class Wordlift_Batch_Analysis_Service {
 			'meta_key'       => self::STATE_META_KEY,
 			'meta_value'     => self::STATE_SUBMIT,
 			'orderby'        => 'ID',
+			'post_type'      => 'any', // Add any because posts from multiple posts types may be waiting.
 		) );
 	}
 
@@ -627,6 +640,7 @@ class Wordlift_Batch_Analysis_Service {
 			'meta_key'       => self::STATE_META_KEY,
 			'meta_value'     => self::STATE_REQUEST,
 			'orderby'        => 'ID',
+			'post_type'      => 'any', // Add any because posts from multiple posts types may be waiting.
 		) );
 	}
 
@@ -728,7 +742,30 @@ class Wordlift_Batch_Analysis_Service {
 			'post_status' => 'any',
 			'meta_key'    => self::WARNING_META_KEY,
 			'meta_value'  => 'yes',
+			'post_type'   => 'any', // Add any because posts from multiple posts types may have warnings.
 		) );
 	}
 
+	/**
+	 * Set the post type which posts have to be analyzes.
+	 *
+	 * @param string $post_type The post type to set.
+	 *
+	 * @since 3.17.0
+	 */
+	public function set_post_type( $post_type ) {
+		$this->post_type = $post_type;
+	}
+
+	/**
+	 * Returns the post type that should be analyzed.
+	 *
+	 * @since 3.17.0
+	 *
+	 * @return string $post_type The post type which posts have to be analyzed.
+	 */
+	public function get_post_type() {
+		// Return post if the post types are not set.
+		return ( ! empty( $this->post_type ) ) ? $this->post_type : 'post';
+	}
 }


### PR DESCRIPTION
Fixes: #726 
Modifications in this PR allows to specify the post type of posts that you want to be analyzed by Batch Analysis. To test, make request to `admin-ajax.php?action=wl_batch_analysis_submit_all_posts&link=yes&post_type=page` and verify that only pages are added in queue for analyzing.