### PR TITLE
Feature729: Mark posts without content as completed, to avoid infinity loops

### DIFF
--- a/src/includes/class-wordlift-batch-analysis-service.php
+++ b/src/includes/class-wordlift-batch-analysis-service.php
@@ -436,6 +436,8 @@ class Wordlift_Batch_Analysis_Service {
 
 				// Continue if the content isn't set.
 				if ( ! isset( $json->content ) || empty( $json->content ) ) {
+					// The post content is empty, so is should be marked as completed.
+					$this->set_state( $id, self::STATE_ERROR );
 					continue;
 				}
 


### PR DESCRIPTION
Fixes: #729 

In this PR we update the post meta to posts without content that has been send to Batch analysis to avoid infinite loops.