### PR TITLE
see #720: Remove all batch analysis hooks and create new one `submit`…

### DIFF
--- a/src/includes/class-wordlift-batch-analysis-adapter.php
+++ b/src/includes/class-wordlift-batch-analysis-adapter.php
@@ -36,59 +36,19 @@ class Wordlift_Batch_Analysis_Adapter {
 	}
 
 	/**
-	 * Submit all the auto selected posts, i.e. non annotated posts.
-	 *
-	 * @since 3.14.2
-	 */
-	public function submit_auto_selected_posts() {
-
-		if ( ! isset( $_REQUEST['link'] ) ) {
-			wp_die( 'The `link` parameter is required.' );
-		}
-
-		$count = $this->batch_analysis_service->submit_auto_selected_posts( $_REQUEST['link'] );
-
-		// Clear any buffer.
-		ob_clean();
-
-		// Send the response.
-		wp_send_json_success( array( 'count' => $count ) );
-
-	}
-
-	/**
-	 * Submit all posts for analysis.
-	 *
-	 * @since 3.14.5
-	 */
-	public function submit_all_posts() {
-
-		if ( ! isset( $_REQUEST['link'] ) ) {
-			wp_die( 'The `link` parameter is required.' );
-		}
-
-		$count = $this->batch_analysis_service->submit_all_posts( $_REQUEST['link'] );
-
-		// Clear any buffer.
-		ob_clean();
-
-		// Send the response.
-		wp_send_json_success( array( 'count' => $count ) );
-
-	}
-
-	/**
-	 * Submit the specified post for batch analysis.
+	 * Submit the posts for batch analysis.
 	 *
 	 * @since 3.14.2
 	 */
 	public function submit() {
 
-		if ( ! isset( $_REQUEST['link'] ) || ! isset( $_REQUEST['post'] ) ) {
-			wp_die( 'The `link` and `post` parameters are required.' );
+		if ( ! isset( $_REQUEST['link'] ) ) {
+			wp_die( 'The `link` parameter is required.' );
 		}
 
-		$count = $this->batch_analysis_service->submit( (array) $_REQUEST['post'], $_REQUEST['link'] );
+		$this->batch_analysis_service->set_params( $_REQUEST );
+
+		$count = $this->batch_analysis_service->submit();
 
 		// Clear any buffer.
 		ob_clean();

--- a/src/includes/class-wordlift.php
+++ b/src/includes/class-wordlift.php
@@ -1389,8 +1389,6 @@ class Wordlift {
 
 		/** Adapters. */
 		$this->loader->add_filter( 'mce_external_plugins', $this->tinymce_adapter, 'mce_external_plugins', 10, 1 );
-		$this->loader->add_action( 'wp_ajax_wl_batch_analysis_submit_auto_selected_posts', $this->batch_analysis_adapter, 'submit_auto_selected_posts', 10 );
-		$this->loader->add_action( 'wp_ajax_wl_batch_analysis_submit_all_posts', $this->batch_analysis_adapter, 'submit_all_posts', 10 );
 		$this->loader->add_action( 'wp_ajax_wl_batch_analysis_submit', $this->batch_analysis_adapter, 'submit', 10 );
 		$this->loader->add_action( 'wp_ajax_wl_batch_analysis_cancel', $this->batch_analysis_adapter, 'cancel', 10 );
 		$this->loader->add_action( 'wp_ajax_wl_batch_analysis_clear_warning', $this->batch_analysis_adapter, 'clear_warning', 10 );


### PR DESCRIPTION
Fixes : #720 

In this PR we remove the `wp_ajax_wl_batch_analysis_submit_all_posts` and `wp_ajax_wl_batch_analysis_submit_auto_selected_posts` and keep the `submit` hook only, with option to add different params.

List of available request options:

* `link` - Whether to set the link or not. Works like it was working before and accepts three options (yes, no, default).
 * `autoselected` - This param replaces `wp_ajax_wl_batch_analysis_submit_auto_selected_posts` hook. When it's set it adds a clause to submit posts without annotations. Available options (yes, no)
 * `include` - This options replaces the old `submit` method where you can add the post id's to be included in the analysis. Available options : post id or list of post ids, comma separated.
 * `exclude` - New param. You can specify the post id or list of post ids, comma separated to be excluded from analysis.
* `from` - New param. You can set a start date(post_date_gmt) from where the analysis should start.
* `to` - New param. You can set a end date(post_date_gmt) where the analysis should end.