### PR TITLE
Feature 681: Fix edit screen permalink issues

### DIFF
--- a/src/modules/core/wordlift_core_constants.php
+++ b/src/modules/core/wordlift_core_constants.php
@@ -4,7 +4,7 @@ define( 'WL_DEFAULT_THUMBNAIL_PATH', dirname( dirname( plugin_dir_url( __FILE__ 
 define( 'WL_DEFAULT_PATH', dirname( dirname( plugin_dir_url( __FILE__ ) ) ) . '/' );
 
 // Database version
-define( 'WL_DB_VERSION', '3.15' );
+define( 'WL_DB_VERSION', '3.16' );
 
 // Custom table name
 define( 'WL_DB_RELATION_INSTANCES_TABLE_NAME', 'wl_relation_instances' );

--- a/src/modules/core/wordlift_core_install.php
+++ b/src/modules/core/wordlift_core_install.php
@@ -229,6 +229,7 @@ function wl_core_upgrade_db_3_12_3_14() {
 	$admins = get_role( 'administrator' );
 
 	$admins->add_cap( 'edit_wordlift_entity' );
+	$admins->add_cap( 'read_wordlift_entity' );
 	$admins->add_cap( 'edit_wordlift_entities' );
 	$admins->add_cap( 'edit_others_wordlift_entities' );
 	$admins->add_cap( 'publish_wordlift_entities' );
@@ -243,6 +244,7 @@ function wl_core_upgrade_db_3_12_3_14() {
 	$editors = get_role( 'editor' );
 
 	$editors->add_cap( 'edit_wordlift_entity' );
+	$editors->add_cap( 'read_wordlift_entity' );
 	$editors->add_cap( 'edit_wordlift_entities' );
 	$editors->add_cap( 'edit_others_wordlift_entities' );
 	$editors->add_cap( 'publish_wordlift_entities' );


### PR DESCRIPTION
Fixes #681 

It seems that editors didn't have permission to `read_wordlift_entity`, which results to broken permalinks in edit entity screen. The [following condition](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/post.php#L1378) didn't pass which returns no href attribute. Adding `read_` capability fixes the issue.

Note: I'm just not sure is it ok to bump the `WL_DB_VERSION `, but since it's not used anywhere else except `wordlift_core_install.php` I think it's ok.