### PR TITLE
Switch the `rl_delete_post` & `wl_core_delete_relation_instances` places

### DIFF
--- a/src/admin/wordlift_admin_save_post.php
+++ b/src/admin/wordlift_admin_save_post.php
@@ -30,11 +30,11 @@ function wl_transition_post_status( $new_status, $old_status, $post ) {
 
 	// transition from *published* to any other status: delete the post.
 	if ( 'publish' === $old_status && 'publish' !== $new_status ) {
-		// Remove all relation instances for the current post from `wl_relation_instances`.
-		wl_core_delete_relation_instances( $post->ID );
-
 		// Delete the post from the triple store.
 		rl_delete_post( $post );
+
+		// Remove all relation instances for the current post from `wl_relation_instances`.
+		wl_core_delete_relation_instances( $post->ID );
 	}
 
 	// when a post is published, then all the referenced entities must be published.


### PR DESCRIPTION
The issue is that when the post is deleted, and the entities didn't have any referencing post, their status should be changed to draft.

By adding the `wl_core_delete_relation_instances` in #763 we delete the references and then when the `rl_delete_post` try to get the related entity ids, they are empty and it fails to change the post status.