### PR TITLE
feat: render custom fields of all selected entities

### DIFF
--- a/src/includes/class-wordlift-entity-type-service.php
+++ b/src/includes/class-wordlift-entity-type-service.php
@@ -95,7 +95,8 @@ class Wordlift_Entity_Type_Service {
 	 *
 	 * @since 3.7.0
 	 *
-	 * @param int $post_id The post id.
+	 * @param int     $post_id  The post id.
+	 * @param boolean $multiple Doesn't break the loop if set to true and returns all found schemas.
 	 *
 	 * @return array|null {
 	 * An array of type properties or null if no term is associated
@@ -107,7 +108,12 @@ class Wordlift_Entity_Type_Service {
 	 * @type array  linked_data   An array of {@link Wordlift_Sparql_Tuple_Rendition}.
 	 * }
 	 */
-	public function get( $post_id ) {
+	public function get( $post_id, $multiple = false ) {
+
+		/**
+		 * Stores all the schemas in an array.
+		 */
+		$schema_array = [];
 
 		$this->log->trace( "Getting the post type for post $post_id..." );
 
@@ -133,11 +139,17 @@ class Wordlift_Entity_Type_Service {
 				// Try to get the schema for the term.
 				$schema = $this->schema_service->get_schema( $term->slug );
 
-				// If found, return it, ignoring the other types.
-				if ( null !== $schema ) {
+				// If found and multiple = false, return it, ignoring the other types.
+				if ( null !== $schema && false === $multiple ) {
 					// Return the entity type with the specified id.
 					return $schema;
+				} elseif ( null !== $schema && true === $multiple ) {
+					$schema_array[] = $schema;
 				}
+			}
+
+			if ( ! empty( $schema_array ) ) {
+				return $schema_array;
 			}
 
 			/*

--- a/src/wordlift_entity_functions.php
+++ b/src/wordlift_entity_functions.php
@@ -199,6 +199,8 @@ function wl_set_entity_rdf_types( $post_id, $type_uris = array() ) {
  */
 function wl_entity_taxonomy_get_custom_fields( $entity_id = null ) {
 
+	$custom_fields = [];
+
 	if ( is_null( $entity_id ) ) {
 
 		// Return all custom fields.
@@ -227,12 +229,27 @@ function wl_entity_taxonomy_get_custom_fields( $entity_id = null ) {
 	}
 
 	// Return custom fields for this specific entity's type.
-	$type = Wordlift_Entity_Type_Service::get_instance()->get( $entity_id );
+	$type = Wordlift_Entity_Type_Service::get_instance()->get( $entity_id, true );
 
-	if ( ! isset( $type['custom_fields'] ) ) {
+	/**
+	 * $type is an array of array since the 2nd param to the function is `true`.
+	 * We'll store the custom fields from all schemas in the $custom_fields array.
+	 */
+	foreach ( $type as $t ) {
+		if ( isset( $t['custom_fields'] ) ) {
+			$custom_fields[] = $t['custom_fields'];
+		}
+	}
+
+	/**
+	 * Return an empty array if the $custom_fields array in empty.
+	 */
+	if ( empty( $custom_fields ) ) {
 		return array();
 	}
 
-	return $type['custom_fields'];
-
+	/**
+	 * This will merge all the sub-arrays and return a unified array of custom fields from all schemas.
+	 */
+	return call_user_func_array( 'array_merge', $custom_fields );
 }


### PR DESCRIPTION
Closes #939 

## Previous functionality
Selecting multiple entities wouldn't render fields in both Gutenberg and Classic editors.

## Current functionality
Selecting multiple entities renders custom fields from all selected entities.

## Screenshot
<img width="1830" alt="Screenshot 2019-10-08 at 9 01 56 AM" src="https://user-images.githubusercontent.com/17757960/66365358-4e5de800-e9aa-11e9-9638-08541e98c4d0.png">

@ziodave I'm not familiar with the entire system, so please let me know if this change has undesired effects in terms of functionality anywhere else.