### PR TITLE
Hotfix: Fix error on logs 

### DIFF
--- a/src/wordlift/mappings/data-source/class-acf-data-source.php
+++ b/src/wordlift/mappings/data-source/class-acf-data-source.php
@@ -53,7 +53,12 @@ class Acf_Data_Source implements Abstract_Data_Source {
 				// Remove non unique values.
 				$repeater_formatted_data = array_unique( $repeater_formatted_data );
 				// Remove empty values
-				$repeater_formatted_data = array_filter( $repeater_formatted_data, 'strlen' );
+				$repeater_formatted_data = array_filter( $repeater_formatted_data, function ( $item ) {
+					if ( is_array( $item ) ) {
+						return true;
+					}
+					return strlen( $item ) > 0;
+				} );
 
 				// re-index all the values.
 				return array_values( $repeater_formatted_data );

--- a/src/wordlift/mappings/data-source/class-acf-data-source.php
+++ b/src/wordlift/mappings/data-source/class-acf-data-source.php
@@ -54,10 +54,7 @@ class Acf_Data_Source implements Abstract_Data_Source {
 				$repeater_formatted_data = array_unique( $repeater_formatted_data );
 				// Remove empty values
 				$repeater_formatted_data = array_filter( $repeater_formatted_data, function ( $item ) {
-					if ( is_array( $item ) ) {
-						return true;
-					}
-					return strlen( $item ) > 0;
+					return is_array( $item ) || strlen( $item );
 				} );
 
 				// re-index all the values.


### PR DESCRIPTION
source: windowsreport

Fixes strlen() expects parameter 1 to be string, array given in /app/web/wp-content/plugins/wordlift/wordlift/mappings/data-source/class-acf-data-source.php on line 56
