### PR TITLE
See #1719: Added Co-Author JSON-LD support.

### DIFF
--- a/src/classes/jsonld/class-jsonld-article-wrapper.php
+++ b/src/classes/jsonld/class-jsonld-article-wrapper.php
@@ -114,7 +114,7 @@ class Jsonld_Article_Wrapper {
 		 * for Person and Organization, so check before we add it to graph.
 		 * reference : https://schema.org/author
 		 */
-		if ( $author_jsonld && ! $this->is_author_entity_present_in_graph( $jsonld, $article_jsonld['author']['@id'] ) ) {
+		if ( $author_jsonld && ! $this->is_author_entity_present_in_graph( $jsonld, $this->get_primary_author($article_jsonld['author'])['@id'] ) ) {
 			$jsonld[] = $author_jsonld;
 		}
 
@@ -128,12 +128,33 @@ class Jsonld_Article_Wrapper {
 		return ! empty( $array_intersect );
 	}
 
+	/**
+	 * Get primary author from author array.
+	 * 
+	 * A helper function that checks the structure of the author array and returns the primary author.
+	 * 
+	 * @param array|string 	$author The author array.
+	 * 
+	 * @return array|string The primary author.
+	 * 
+	 * @since 3.51.4
+	 */
+	private function get_primary_author( $author ) {
+		
+		// Nested array of co-authors. Return the primary author.
+		if ( ! isset( $author['@id'] ) ) {
+			return $author[0];
+		}
+
+		return $author;
+	}
+
 	private function get_author_linked_entity( $article_jsonld ) {
 		if ( ! array_key_exists( 'author', $article_jsonld ) ) {
 			return false;
 		}
 
-		$author = $article_jsonld['author'];
+		$author = $this->get_primary_author( $article_jsonld['author'] );
 
 		if ( count( array_keys( $author ) ) !== 1 || ! array_key_exists( '@id', $author ) ) {
 			return false;

--- a/src/classes/jsonld/class-jsonld-article-wrapper.php
+++ b/src/classes/jsonld/class-jsonld-article-wrapper.php
@@ -109,12 +109,17 @@ class Jsonld_Article_Wrapper {
 
 		$author_jsonld = $this->get_author_linked_entity( $article_jsonld );
 
+		
+		// Get primary author in case co-authors exist.
+		$primary_author = $this->get_primary_author($article_jsonld['author']);
+		
 		/**
 		 * The author entities can be present in graph for some entity types
 		 * for Person and Organization, so check before we add it to graph.
 		 * reference : https://schema.org/author
 		 */
-		if ( $author_jsonld && ! $this->is_author_entity_present_in_graph( $jsonld, $this->get_primary_author($article_jsonld['author'])['@id'] ) ) {
+
+		if ( $author_jsonld && ! $this->is_author_entity_present_in_graph( $jsonld, $primary_author['@id'] ) ) {
 			$jsonld[] = $author_jsonld;
 		}
 
@@ -142,7 +147,7 @@ class Jsonld_Article_Wrapper {
 	private function get_primary_author( $author ) {
 		
 		// Nested array of co-authors. Return the primary author.
-		if ( ! isset( $author['@id'] ) ) {
+		if ( is_array( $author ) && ! empty( $author ) && ! isset( $author['@id'] ) ) {
 			return $author[0];
 		}
 

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -185,7 +185,7 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 		 * 
 		 * @see https://www.geeklab.info/2010/04/wordpress-pass-variables-by-reference-with-apply_filter/
 		 */
-		$jsonld['author'] = apply_filters(
+		$ret_val = apply_filters(
 			'wl_jsonld_author',
 			array(
 				'author' 	 => $this->get_author( $post->post_author, $references ),
@@ -193,6 +193,10 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 			),
 			$post_id
 		);
+
+		// Set the values returned by the filter.
+		$jsonld['author'] = $ret_val['author'];
+		$references       = $ret_val['references'];
 
 		// Return the JSON-LD if filters are disabled by the client.
 		if ( $this->disable_convert_filters ) {

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -167,8 +167,32 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 		// Set the publisher.
 		$this->set_publisher( $jsonld );
 
-		// Finally set the author.
-		$jsonld['author'] = $this->get_author( $post->post_author, $references );
+		/**
+		 * Call the `wl_post_jsonld_author` filter.
+		 * 
+		 * This filter checks if there are co-authors or a single author and
+		 * returns a JSON-LD fragment for the author(s).
+		 * 
+		 * @param array $value {
+		 * 
+		 * @type array $jsonld The JSON-LD structure.
+		 * @type int[] $references An array of post IDs.
+		 * }
+		 * 
+		 * @param int $post_id The {@link WP_Post} `id`.
+		 * 
+		 * @since 3.51.4
+		 * 
+		 * @see https://www.geeklab.info/2010/04/wordpress-pass-variables-by-reference-with-apply_filter/
+		 */
+		$jsonld['author'] = apply_filters(
+			'wl_jsonld_author',
+			array(
+				'author' 	 => $this->get_author( $post->post_author, $references ),
+				'references' => $references
+			),
+			$post_id
+		);
 
 		// Return the JSON-LD if filters are disabled by the client.
 		if ( $this->disable_convert_filters ) {

--- a/src/modules/jsonld-author-filter/load.php
+++ b/src/modules/jsonld-author-filter/load.php
@@ -12,7 +12,7 @@
  * }
  * @param int $post_id The post ID.
  *
- * @return string|array A JSON-LD structure.
+ * @return array An array with the updated JSON-LD and references.
  * 
  * @since 3.51.4
  * 
@@ -26,7 +26,7 @@ function _wl_jsonld_author__author_filter( $args_arr, $post_id ) {
     $coauthor_plugin_path = 'co-authors-plus/co-authors-plus.php';
 
     // If the co-authors plugin is active.
-    if ( is_plugin_active( $coauthor_plugin_path ) ) {
+    if ( is_plugin_active( $coauthor_plugin_path ) && function_exists( 'get_coauthors' ) ) {
 
         $coauthors = get_coauthors( $post_id );
 
@@ -43,7 +43,10 @@ function _wl_jsonld_author__author_filter( $args_arr, $post_id ) {
         }
     }
 
-    return $author;
+    return array(
+        'author'     => $author,
+        'references' => $references,
+    );
 }
 
 // Add the filter

--- a/src/modules/jsonld-author-filter/load.php
+++ b/src/modules/jsonld-author-filter/load.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Filter the author object to add the co-authors.
+ * 
+ * This filter checks if there are co-authors or a single author and
+ * returns a JSON-LD fragment for the author(s).
+ * 
+ * @param array $value {
+ *     @type array $author      The author JSON-LD structure.
+ *     @type int[] $references  An array of post IDs.
+ * }
+ * @param int $post_id The post ID.
+ *
+ * @return string|array A JSON-LD structure.
+ * 
+ * @since 3.51.4
+ * 
+ * @see https://www.geeklab.info/2010/04/wordpress-pass-variables-by-reference-with-apply_filter/
+ */
+function _wl_jsonld_author__author_filter( $args_arr, $post_id ) {
+
+    $author     = $args_arr['author'];
+    $references = $args_arr['references'];
+
+    $coauthor_plugin_path = 'co-authors-plus/co-authors-plus.php';
+
+    // If the co-authors plugin is active.
+    if ( is_plugin_active( $coauthor_plugin_path ) ) {
+
+        $coauthors = get_coauthors( $post_id );
+
+        // And we have multiple authors on a post.
+        if ( count( $coauthors ) > 1 ) {
+
+            // Clear the existing author.
+            $author = array();
+    
+            // Build array of authors.
+            foreach ( $coauthors as $coauthor ) {
+                $author[] = Wordlift_Post_To_Jsonld_Converter::get_instance()->get_author( $coauthor->ID, $references );
+            }
+        }
+    }
+
+    return $author;
+}
+
+// Add the filter
+add_filter('wl_jsonld_author', '_wl_jsonld_author__author_filter', 10, 2);

--- a/src/wordlift.php
+++ b/src/wordlift.php
@@ -320,6 +320,7 @@ require_once __DIR__ . '/modules/raptive-setup/load.php';
 require_once __DIR__ . '/modules/events/load.php';
 require_once __DIR__ . '/modules/plugin-diagnostics/load.php';
 require_once __DIR__ . '/modules/override-url/load.php';
+require_once __DIR__ . '/modules/jsonld-author-filter/load.php';
 
 function _wl_update_plugins_raptive_domain( $update, $plugin_data, $plugin_file ) {
 	// Bail out if it's not our plugin.


### PR DESCRIPTION
- Created a module that registers a filter `wl_jsonld_author` which checks if the `co-author-plus` plugin is active and conditionally filters the author JSON-LD array passed to it if co-authors exist on a post.
- Added the filters to the construction of the JSON-LD object.
- Created a helper function to get the primary author if there are multiple
- Rewrote code in the `Jsonld_Article_Wrapper` class to ensure we are checking the primary author.