### PR TITLE
See #1728: Add check for false @id in Author JSON-LD.

### DIFF
--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -202,7 +202,7 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 		 *
 		 * @since 3.53.2
 		 */
-		if ( ! empty ( $ret_val['author'] ) ) {
+		if ( ! empty( $ret_val['author'] ) ) {
 			$jsonld['author'] = $ret_val['author'];
 			$references       = $ret_val['references'];
 		}

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -194,9 +194,18 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 			$post_id
 		);
 
-		// Set the values returned by the filter.
-		$jsonld['author'] = $ret_val['author'];
-		$references       = $ret_val['references'];
+		// Set the values returned by the author filter.
+		/*
+		 * Do not add the author JSON-LD if an invalid author was referenced in a post.
+		 *
+		 * @see https://github.com/insideout10/wordlift-plugin/issues/1728
+		 *
+		 * @since 3.53.2
+		 */
+		if ( false !== $ret_val['author']['@id'] ) {
+			$jsonld['author'] = $ret_val['author'];
+			$references       = $ret_val['references'];
+		}
 
 		// Return the JSON-LD if filters are disabled by the client.
 		if ( $this->disable_convert_filters ) {


### PR DESCRIPTION
We added a check after the wl_jsonld_author filter in the Post conversion to ensure we don't render a bad author JSON-LD in the edge case when a Post has an invalid author set.