### PR TITLE
See #1731: Article wrapper JSON-LD issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wordlift-plugin",
   "description": "WordLift brings the power of Artificial Intelligence to organize content. Attract new readers and get their true attention with top notch semantic seo.",
   "private": true,
-  "version": "3.52.0",
+  "version": "3.53.0-0",
   "author": "WordLift",
   "homepage": "https://wordift.io/",
   "license": "GPL-3.0",

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -96,12 +96,6 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 		// Get the entity name.
 		$jsonld['headline'] = $post->post_title;
 
-		$custom_fields = $this->entity_type_service->get_custom_fields_for_post( $post_id );
-
-		if ( isset( $custom_fields ) ) {
-			$this->process_type_custom_fields( $jsonld, $custom_fields, $post, $references, $references_infos );
-		}
-
 		// Set the published and modified dates.
 		/*
 		 * Set the `datePublished` and `dateModified` using the local timezone.

--- a/src/wordlift.php
+++ b/src/wordlift.php
@@ -15,7 +15,7 @@
  * Plugin Name:       WordLift
  * Plugin URI:        https://wordlift.io
  * Description:       WordLift brings the power of AI to organize content, attract new readers and get their attention. To activate the plugin <a href="https://wordlift.io/">visit our website</a>.
- * Version:           3.52.0
+ * Version:           3.53.0-0
  * Author:            WordLift
  * Author URI:        https://wordlift.io
  * License:           GPL-2.0+
@@ -32,7 +32,7 @@ use Wordlift\Features\Features_Registry;
 use Wordlift\Post\Post_Adapter;
 
 define( 'WORDLIFT_PLUGIN_FILE', __FILE__ );
-define( 'WORDLIFT_VERSION', '3.52.0' );
+define( 'WORDLIFT_VERSION', '3.53.0-0' );
 
 // ## DO NOT REMOVE THIS LINE: WHITELABEL PLACEHOLDER ##
 


### PR DESCRIPTION
Removed custom field expansion in post_converter to prevent entity custom fields from being left in article when the article wrapper feature is enabled.