### PR TITLE
Fix article wrapper issue with JSON-LD properties.

### DIFF
--- a/src/includes/class-wordlift-entity-type-service.php
+++ b/src/includes/class-wordlift-entity-type-service.php
@@ -294,7 +294,7 @@ class Wordlift_Entity_Type_Service {
 	 *                             or `$term` was not found.
 	 * @since 3.20.0
 	 */
-	private function get_term_by_slug( $slug ) {
+	public function get_term_by_slug( $slug ) {
 
 		return get_term_by( 'slug', $slug, Wordlift_Entity_Type_Taxonomy_Service::TAXONOMY_NAME );
 	}

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -96,12 +96,12 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 		// Get the entity name.
 		$jsonld['headline'] = $post->post_title;
 
-        // Convert entities as `Article`.
-        //
-        // @see https://github.com/insideout10/wordlift-plugin/issues/1731
-        $custom_fields = Wordlift_Entity_Service::get_instance()->is_entity( $post_id )
-            ? $this->entity_type_service->get_custom_fields_for_term( $this->entity_type_service->get_term_by_slug( 'article' ) )
-            : $this->entity_type_service->get_custom_fields_for_post( $post_id );
+		// Convert entities as `Article`.
+		//
+		// @see https://github.com/insideout10/wordlift-plugin/issues/1731
+		$custom_fields = Wordlift_Entity_Service::get_instance()->is_entity( $post_id )
+			? $this->entity_type_service->get_custom_fields_for_term( $this->entity_type_service->get_term_by_slug( 'article' ) )
+			: $this->entity_type_service->get_custom_fields_for_post( $post_id );
 
 		if ( isset( $custom_fields ) ) {
 			$this->process_type_custom_fields( $jsonld, $custom_fields, $post, $references, $references_infos );

--- a/src/includes/class-wordlift-post-to-jsonld-converter.php
+++ b/src/includes/class-wordlift-post-to-jsonld-converter.php
@@ -96,7 +96,12 @@ class Wordlift_Post_To_Jsonld_Converter extends Wordlift_Abstract_Post_To_Jsonld
 		// Get the entity name.
 		$jsonld['headline'] = $post->post_title;
 
-		$custom_fields = $this->entity_type_service->get_custom_fields_for_post( $post_id );
+        // Convert entities as `Article`.
+        //
+        // @see https://github.com/insideout10/wordlift-plugin/issues/1731
+        $custom_fields = Wordlift_Entity_Service::get_instance()->is_entity( $post_id )
+            ? $this->entity_type_service->get_custom_fields_for_term( $this->entity_type_service->get_term_by_slug( 'article' ) )
+            : $this->entity_type_service->get_custom_fields_for_post( $post_id );
 
 		if ( isset( $custom_fields ) ) {
 			$this->process_type_custom_fields( $jsonld, $custom_fields, $post, $references, $references_infos );


### PR DESCRIPTION
The article wrapper was expanding entity posts then overriding the type, leaving entity custom fields in the article jsonld. So we add a check to the Wordlift_Post_To_Jsonld_Converter class to expand the custom fields as article if the post is an entity (i.e. not article).