### PR TITLE
fix: Fix character offset desync during content analysis (backtick pa…

### DIFF
--- a/src/modules/analyzer/wordlift-analyzer.php
+++ b/src/modules/analyzer/wordlift-analyzer.php
@@ -40,7 +40,9 @@ function wl_ajax_analyze_action() {
 
 	if ( isset( $_POST['data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		// We need to send the data from editor without sanitizing to analysis service.
-		$filtered_data = filter_var_array( $_POST, array( 'data' => array( 'flags' => FILTER_UNSAFE_RAW ) ) );
+		// Passing FILTER_UNSAFE_RAW (516) inside 'flags' activates bit 512 (FILTER_FLAG_STRIP_BACKTICK), eating backticks!
+		// The fixed code uses 'filter' implicitly by passing the filter constant directly:
+		$filtered_data = filter_var_array( $_POST, array( 'data' => FILTER_UNSAFE_RAW ) );
 		$data          = $filtered_data['data'];
 	}
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -6,7 +6,7 @@ Tags: SEO, structured data, ai, linked data, semantic web
 Requires at least: 5.3
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 3.54.10
+Stable tag: 3.54.11
 License: GPLv2 or later
 
 Search engines are looking for meaning, not keywords. WordLift tells Google how your content relates to your brand, products, and stakeholders.
@@ -146,6 +146,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 9. The WordLift Dashboard. Your [knowledge graph](http://docs.wordlift.io/en/latest/key-concepts.html#knowledge-graph) at a glance.
 
 == Changelog ==
+
+= 3.54.11 (2026-06-25) =
+
+* Fix: character offset desync during content analysis (backtick parsing bug)
 
 = 3.54.10 (2026-04-01) =
 

--- a/src/wordlift.php
+++ b/src/wordlift.php
@@ -15,7 +15,7 @@
  * Plugin Name:       WordLift
  * Plugin URI:        https://wordlift.io
  * Description:       WordLift brings the power of AI to organize content, attract new readers and get their attention. To activate the plugin <a href="https://wordlift.io/">visit our website</a>.
- * Version:           3.54.10
+ * Version:           3.54.11
  * Requires PHP:      7.4
  * Requires at least: 5.3
  * Author:            WordLift
@@ -34,7 +34,7 @@ use Wordlift\Features\Features_Registry;
 use Wordlift\Post\Post_Adapter;
 
 define( 'WORDLIFT_PLUGIN_FILE', __FILE__ );
-define( 'WORDLIFT_VERSION', '3.54.10' );
+define( 'WORDLIFT_VERSION', '3.54.11' );
 
 // ## DO NOT REMOVE THIS LINE: WHITELABEL PLACEHOLDER ##
 


### PR DESCRIPTION
Fixed a subtle bug in `wl_ajax_analyze_action` where `FILTER_UNSAFE_RAW` was incorrectly passed inside the `flags` parameter of `filter_var_array`. 
Because no `filter` ID was explicitly provided, PHP defaulted to `FILTER_SANITIZE_STRING` and treated the integer value of `FILTER_UNSAFE_RAW` (516) as a bitwise flag mask. Since 516 contains the `FILTER_FLAG_STRIP_BACKTICK` (512) bit, PHP was silently stripping all backticks from the editor payload (as well as stripping all HTML tags due to the default sanitize filter). 
This corrupted the payload before it was sent to the analysis service, causing a length mismatch between the frontend editor HTML and the backend text payload. This mismatch resulted in shifted character offsets when Wordlift attempted to highlight the annotated text.
Passing `FILTER_UNSAFE_RAW` directly corrects the syntax to properly apply the filter, preserving the raw HTML payload as originally intended.